### PR TITLE
[#185361601] Added support for a basic auth profile

### DIFF
--- a/src/main/java/com/dnastack/wes/security/AuthConfig.java
+++ b/src/main/java/com/dnastack/wes/security/AuthConfig.java
@@ -5,9 +5,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 
@@ -17,9 +20,10 @@ import java.util.List;
 @ConfigurationProperties(prefix = "wes.auth")
 public class AuthConfig {
 
+    AuthMethod method;
 
     /**
-     * The list of trusted token issuers for incoming requests. All Tokens must have originated at at least one of these
+     * The trusted token issuer for incoming requests. All Tokens must have originated at at least one of these
      * configured issues. Validity of the token is determined by a 1) Validity of the JWT (time), 2) Validity of the
      * issuerUri in the JWT header 3) validity of the audience if it is present in the issuerConfig 4) validity of the
      * configured scopes, if they are present in the issuer config
@@ -28,10 +32,44 @@ public class AuthConfig {
 
     HttpClientConfig httpClientConfig;
 
+    BasicAuthConfig basicAuth;
+
+
+    public enum AuthMethod {
+        NO_AUTH,
+        BASIC_AUTH,
+        PASSPORT,
+        OAUTH;
+    }
+
     @Data
     public static class HttpClientConfig {
+
         private int maxIdleConnections;
         private Duration keepAliveTimeout;
+
+    }
+
+
+    @Data
+    public static class BasicAuthConfig {
+
+        List<User> users;
+        boolean bcrypted = false;
+
+    }
+
+    @Data
+    public static class User implements UserDetails {
+
+        private final Collection<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        private final boolean accountNonExpired = true;
+        private final boolean accountNonLocked = true;
+        private final boolean credentialsNonExpired = true;
+        private final boolean enabled = true;
+        private String password;
+        private String username;
+
     }
 
 

--- a/src/main/java/com/dnastack/wes/security/BasicAuthSecurityConfig.java
+++ b/src/main/java/com/dnastack/wes/security/BasicAuthSecurityConfig.java
@@ -1,0 +1,69 @@
+package com.dnastack.wes.security;
+
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Objects;
+
+@Configuration
+@ConditionalOnExpression("'${wes.auth.method}' == 'BASIC_AUTH'")
+public class BasicAuthSecurityConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService(AuthConfig config) {
+        return username -> config.getBasicAuth().getUsers().stream().filter(user -> username.equals(user.getUsername()))
+            .findAny().orElseThrow(() -> new UsernameNotFoundException("Username %s could not be found".formatted(username)));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(AuthConfig config) {
+        if (config.getBasicAuth().isBcrypted()) {
+            return new BCryptPasswordEncoder();
+        } else {
+            return new PasswordEncoder() {
+                @Override
+                public String encode(CharSequence rawPassword) {
+                    return rawPassword.toString();
+                }
+
+                @Override
+                public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                    return Objects.equals(rawPassword.toString(), encodedPassword);
+                }
+            };
+        }
+    }
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .cors()
+            .disable()
+            .csrf()
+            .disable()
+            .authorizeRequests()
+            .antMatchers("/services", "/actuator/info**", "/actuator/health", "/actuator/health/**", "/service-info", "/docs/**")
+            .permitAll()
+            .antMatchers("/ga4gh/wes/v1/service-info")
+            .permitAll()
+            .antMatchers("/actuator/**")
+            .authenticated()
+            .antMatchers("/**")
+            .authenticated()
+            .and()
+            .httpBasic();
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/dnastack/wes/security/NoAuthSecurityConfig.java
+++ b/src/main/java/com/dnastack/wes/security/NoAuthSecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 
 @Configuration
-@ConditionalOnExpression("!${security.authentication.enabled:false}")
+@ConditionalOnExpression("'${wes.auth.method}' == 'NO_AUTH'")
 public class NoAuthSecurityConfig {
 
     @Bean
@@ -24,5 +24,6 @@ public class NoAuthSecurityConfig {
             .permitAll();
         return http.build();
     }
+
 
 }

--- a/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
+++ b/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
@@ -29,28 +29,12 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 @EnableMethodSecurity
-@ConditionalOnExpression("${security.authentication.enabled:true} && ${securtiy.authorization.enabled:true}")
-public class AuthorizedSecurityConfiguration {
+@ConditionalOnExpression("'${wes.auth.method}' == 'PASSPORT'")
+public class PassportSecurityConfiguration {
 
     @Bean
     public AccessEvaluator accessEvaluator(AuthConfig authConfig, PermissionChecker permissionChecker) {
         return new AccessEvaluator(authConfig, permissionChecker);
-    }
-
-    @Bean
-    // purposefully uses same qualifier as bean in spring-wallet-token-validator library in case we ever start using
-    // that library in Explorer
-    @Qualifier("com.dnastack.auth.token-validator-connection-pool")
-    public ConnectionPool getConnectionPool(AuthConfig authConfig) {
-        final AuthConfig.HttpClientConfig httpClientConfig = authConfig.getHttpClientConfig();
-        final Duration keepAliveTimeout = httpClientConfig.getKeepAliveTimeout();
-        if (keepAliveTimeout.toNanosPart() > 0 || keepAliveTimeout.toMillisPart() > 0) {
-            throw new IllegalArgumentException("Given keep alive value of [%s] must not have granularity below seconds".formatted(keepAliveTimeout));
-        }
-        final long convertedTimeout = keepAliveTimeout.toSeconds();
-        final TimeUnit convertedTimeUnit = TimeUnit.SECONDS;
-
-        return new ConnectionPool(httpClientConfig.getMaxIdleConnections(), convertedTimeout, convertedTimeUnit);
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -81,6 +81,8 @@ wes:
       staging-path: uploads/
 
   auth:
+    # Can be BASIC_AUTH, NO_AUTH, OAUTH, PASSPORT
+    method: PASSPORT
     issuer-uri: http://localhost:8081
     token-issuer:
       # Default Token issuer to use
@@ -196,27 +198,45 @@ springdoc:
     path: /docs/openapi.json
   swagger-ui:
     path: /docs/swagger-ui.html
-
 security:
   authentication:
     enabled: true
-  authorization:
-    enabled: true
+
+
+---
+spring:
+  config:
+    activate:
+      on-profile: oauth
+wes:
+  auth:
+    method: OAUTH
+
+---
+spring:
+  config:
+    activate:
+      on-profile: basic-auth
+wes:
+  auth:
+    method: BASIC_AUTH
+    basic-auth:
+      bcrypted: false
 
 ---
 spring:
   config:
     activate:
       on-profile: no-auth
-security:
-  authentication:
-    enabled: false
-  authorization:
-    enabled: false
+wes:
+  auth:
+    method: NO_AUTH
 server:
   # Bind this only to localhost
   address: 127.0.0.1
-
+security:
+  authentication:
+    enabled: false
 ---
 spring:
   config:


### PR DESCRIPTION
This change modifies how auth works and adds support for a basic auth profile.

Change:
1. Auth now is toggled by the `wes.auth.method`  (`AuthMethod`) enum
2. Added a basic auth profile
3. Updated docs 