### PR TITLE
[#186151481] added support for range lookups with range header

### DIFF
--- a/e2e-tests/src/main/java/com/dnastack/wes/service/WesE2ETest.java
+++ b/e2e-tests/src/main/java/com/dnastack/wes/service/WesE2ETest.java
@@ -7,6 +7,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.http.ContentType;
+import io.restassured.http.Header;
 import io.restassured.specification.MultiPartSpecification;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.*;
@@ -605,7 +606,6 @@ public class WesE2ETest extends BaseE2eTest {
                 .jsonPath()
                 .getString("run_id");
             //@formatter:on
-            final String runPathStatus = format("%s/%s/status", path, workflowJobId);
             pollUntilJobCompletes(workflowJobId);
         }
 
@@ -649,6 +649,43 @@ public class WesE2ETest extends BaseE2eTest {
 
             Assertions.assertEquals("Hello Frank\n",body);
 
+            // test range offset
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=0-4")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stdout"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("Hello",body);
+
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=6-")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stdout"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("Frank\n",body);
+
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=1-3")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stdout"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("ell",body);
+
             //@formatter:on
 
             //@formatter:off
@@ -663,6 +700,43 @@ public class WesE2ETest extends BaseE2eTest {
 
             Assertions.assertEquals("Goodbye Frank\n",body);
             //@formatter:on
+
+            // test range offset
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=0-4")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stderr"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("Goodb",body);
+
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=8-")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stderr"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("Frank\n",body);
+
+            body = given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=1-3")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stderr"))
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+            Assertions.assertEquals("ood",body);
         }
 
         @Test

--- a/e2e-tests/src/main/java/com/dnastack/wes/service/WesE2ETest.java
+++ b/e2e-tests/src/main/java/com/dnastack/wes/service/WesE2ETest.java
@@ -657,7 +657,7 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stdout"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("Hello",body);
@@ -669,7 +669,7 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stdout"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("Frank\n",body);
@@ -681,7 +681,7 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stdout"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("ell",body);
@@ -709,7 +709,7 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stderr"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("Goodb",body);
@@ -721,7 +721,7 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stderr"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("Frank\n",body);
@@ -733,10 +733,19 @@ public class WesE2ETest extends BaseE2eTest {
                 .header(getHeader(getResource(path)))
                 .get(taskLogs.get("stderr"))
                 .then()
-                .statusCode(200)
+                .statusCode(206)
                 .extract().asString();
 
             Assertions.assertEquals("ood",body);
+
+            given()
+                .log().uri()
+                .log().method()
+                .header("Range","bytes=1-3,6-9")
+                .header(getHeader(getResource(path)))
+                .get(taskLogs.get("stderr"))
+                .then()
+                .statusCode(416);
         }
 
         @Test

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -22,7 +22,7 @@ following will provide certificates for hostname `127.0.0.1`.
 cd cert
 
 # Generate server cert to be signed
-openssl req -new -nodes -x509 -days 365 -keyout server.key -out server.crt -config server.conf
+openssl req -new -nodes -x509 -days 365 -keyout server.pem -out server.crt -config server.conf
 
 # Generate client cert to be signed
 openssl req -new -nodes -x509 -days 365 -keyout client.key -out client.crt -config client.conf

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.12</version>
+        <version>2.7.15</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -28,13 +28,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <spring-cloud.version>2021.0.5</spring-cloud.version>
+        <spring-cloud.version>2021.0.8</spring-cloud.version>
         <logback.version>1.2.10</logback.version>
         <logback-extensions.version>1.0.0</logback-extensions.version>
         <logback.contrib.version>0.1.5</logback.contrib.version>
         <springdoc.version>1.6.13</springdoc.version>
-        <dnastack-token-validator.version>1.0.8</dnastack-token-validator.version>
-        <audit-event-logger.version>1.0.9</audit-event-logger.version>
+        <dnastack-token-validator.version>1.0.9</dnastack-token-validator.version>
+        <audit-event-logger.version>1.0.15</audit-event-logger.version>
         <okhttpclient.version>4.9.3</okhttpclient.version>
         <jwt.version>0.11.2</jwt.version>
         <feign-form.version>3.8.0</feign-form.version>
@@ -42,7 +42,9 @@
         <sonar.dependencyCheck.jsonReportPath>target/dependency-check-report.json</sonar.dependencyCheck.jsonReportPath>
         <sonar.dependencyCheck.htmlReportPath>target/dependency-check-report.html</sonar.dependencyCheck.htmlReportPath>
         <sonar.dependencyCheck.summarize>true</sonar.dependencyCheck.summarize>
-        <gcloud.version>9.1.0</gcloud.version>
+        <azure-sdk.version>1.2.8</azure-sdk.version>
+        <gcloud.storage.version>2.20.1</gcloud.storage.version>
+        <gcloud.auth.version>1.16.0</gcloud.auth.version>
     </properties>
 
     <dependencyManagement>
@@ -72,9 +74,23 @@
                 <version>${logback.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>${azure-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>libraries-bom</artifactId>
-                <version>${gcloud.version}</version>
+                <artifactId>google-cloud-storage-bom</artifactId>
+                <version>${gcloud.storage.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.auth</groupId>
+                <artifactId>google-auth-library-bom</artifactId>
+                <version>${gcloud.auth.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -198,11 +214,14 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>${azurestorage.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/dnastack/wes/api/RangeNotSatisfiableException.java
+++ b/src/main/java/com/dnastack/wes/api/RangeNotSatisfiableException.java
@@ -1,0 +1,9 @@
+package com.dnastack.wes.api;
+
+public class RangeNotSatisfiableException extends RuntimeException {
+
+    public RangeNotSatisfiableException(String s) {
+        super(s);
+    }
+
+}

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -10,6 +10,8 @@ import com.dnastack.wes.workflow.WorkflowAuthorizerService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRange;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -123,36 +126,68 @@ public class WesV1Controller {
     @AuditActionUri("wes:run:stderr")
     @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void getStderr(HttpServletResponse response, @PathVariable String runId) throws IOException {
-        adapter.getLogBytes(response.getOutputStream(), runId);
+    public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
+        adapter.getLogBytes(response.getOutputStream(), runId,getRangeFromHeaders(headers));
     }
 
     @AuditActionUri("wes:run:stderr")
     @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void getStderr(HttpServletResponse response, @PathVariable String runId, @PathVariable String taskId) throws IOException {
-        adapter.getLogBytes(response.getOutputStream(), runId, taskId, "stderr");
+    public void getTaskStderr(
+        HttpServletResponse response,
+        @RequestHeader HttpHeaders headers,
+        @PathVariable String runId,
+        @PathVariable String taskId
+    ) throws IOException {
+        adapter.getLogBytes(response.getOutputStream(), runId, taskId, "stderr",getRangeFromHeaders(headers));
     }
 
     @AuditActionUri("wes:run:stdout")
     @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void getStdout(HttpServletResponse response, @PathVariable String runId, @PathVariable String taskId) throws IOException {
-        adapter.getLogBytes(response.getOutputStream(), runId, taskId, "stdout");
+    public void getTaskStdout(
+        HttpServletResponse response,
+        @RequestHeader HttpHeaders headers,
+        @PathVariable String runId,
+        @PathVariable String taskId
+    ) throws IOException {
+        adapter.getLogBytes(response.getOutputStream(), runId, taskId, "stdout",getRangeFromHeaders(headers));
     }
 
     @AuditActionUri("wes:run:stderr")
     @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void getStderr(HttpServletResponse response, @PathVariable String runId, @PathVariable String taskName, @PathVariable int index) throws IOException {
-        adapter.getLogBytes(response.getOutputStream(), runId, taskName, index, "stderr");
+    public void getTaskStderr(
+        HttpServletResponse response,
+        @RequestHeader HttpHeaders headers,
+        @PathVariable String runId,
+        @PathVariable String taskName,
+        @PathVariable int index
+    ) throws IOException {
+        adapter.getLogBytes(response.getOutputStream(), runId, taskName, index, "stderr",getRangeFromHeaders(headers));
     }
 
     @AuditActionUri("wes:run:stdout")
     @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void getStdout(HttpServletResponse response, @PathVariable String runId, @PathVariable String taskName, @PathVariable int index) throws IOException {
-        adapter.getLogBytes(response.getOutputStream(), runId, taskName, index, "stdout");
+    public void getTaskStdout(
+        HttpServletResponse response,
+        @RequestHeader HttpHeaders headers,
+        @PathVariable String runId,
+        @PathVariable String taskName,
+        @PathVariable int index
+    ) throws IOException {
+        adapter.getLogBytes(response.getOutputStream(), runId, taskName, index, "stdout", getRangeFromHeaders(headers));
+    }
+
+    private HttpRange getRangeFromHeaders(HttpHeaders headers){
+        List<HttpRange> ranges = headers.getRange();
+        if (ranges.isEmpty()){
+            return null;
+        } else {
+            // only return the first range parsed
+            return ranges.get(0);
+        }
     }
 
 }

--- a/src/main/java/com/dnastack/wes/shared/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/dnastack/wes/shared/GlobalControllerExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.dnastack.wes.shared;
 
 import com.dnastack.wes.api.ErrorResponse;
+import com.dnastack.wes.api.RangeNotSatisfiableException;
 import com.dnastack.wes.workflow.UnauthorizedWorkflowException;
 import feign.FeignException;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +38,12 @@ public class GlobalControllerExceptionHandler {
     public ResponseEntity<ErrorResponse> handle(FeignException ex) {
         return ResponseEntity.status(ex.status())
             .body(ErrorResponse.builder().msg(ex.getMessage()).errorCode(ex.status()).build());
+    }
+
+    @ExceptionHandler(RangeNotSatisfiableException.class)
+    public ResponseEntity<ErrorResponse> handle(RangeNotSatisfiableException ex) {
+        return ResponseEntity.status(416)
+            .body(ErrorResponse.builder().msg(ex.getMessage()).errorCode(416).build());
     }
 
 }

--- a/src/main/java/com/dnastack/wes/storage/BlobStorageClient.java
+++ b/src/main/java/com/dnastack/wes/storage/BlobStorageClient.java
@@ -1,5 +1,8 @@
 package com.dnastack.wes.storage;
 
+import org.springframework.http.HttpRange;
+
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -12,10 +15,10 @@ public interface BlobStorageClient {
     String writeBytes(InputStream stream, long uploadSize, String stagingFolder, String fileName) throws IOException;
 
     default void getBytes(OutputStream outputStream, String blobUri) throws IOException {
-        readBytes(outputStream, blobUri, null, null);
+        readBytes(outputStream, blobUri, null);
     }
 
 
-    void readBytes(OutputStream outputStream, String blobUri, Long rangeStart, Long rangeEnd) throws IOException;
+    void readBytes(OutputStream outputStream, String blobUri, @Nullable HttpRange  httpRange) throws IOException;
 
 }

--- a/src/main/java/com/dnastack/wes/storage/BoundedInputStream.java
+++ b/src/main/java/com/dnastack/wes/storage/BoundedInputStream.java
@@ -1,0 +1,171 @@
+package com.dnastack.wes.storage;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+public class BoundedInputStream extends InputStream {
+
+
+    /**
+     * The wrapped input stream.
+     */
+    private final InputStream inputStream;
+
+
+    /**
+     * The limit, -1 if none.
+     */
+    private final long maxPos;
+
+
+    /**
+     * The current position of the inner input stream.
+     */
+    private long pos;
+
+    /**
+     * The offset at which to start reading bytes in the inner input stream.
+     */
+    private final long minPos;
+
+
+    /**
+     * Marks the input stream.
+     */
+    private long mark;
+
+
+    /**
+     * Creates a new bounded input stream.
+     *
+     * @param in   The input stream to wrap.
+     * @param size The maximum number of bytes to return, -1 if no limit.
+     */
+    public BoundedInputStream(final InputStream in, final long size) {
+        this(in, 0L, size);
+    }
+
+    /**
+     * Creates a new bounded input stream.
+     *
+     * @param in   The input stream to wrap.
+     * @param minPos  The starting offset for the bounded input stream; bytes before the offset will be skipped.
+     * @param size The maximum number of bytes to return, -1 if no limit.
+     */
+    public BoundedInputStream(final InputStream in, final long minPos, final long size) {
+        this.minPos = minPos;
+        this.pos = 0L;
+        this.mark = -1L;
+        this.maxPos = size >= 0 ? minPos + size : -1L;
+        this.inputStream = in;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (isEndOfStream()) {
+            return -1;
+        }
+        skipBytesBeforeOffset();
+        int result = this.inputStream.read();
+        if (result >= 0) {
+            this.pos++;
+        }
+        return result;
+    }
+
+    @Override
+    public int read(@NotNull byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(@NotNull byte[] b, int off, int len) throws IOException {
+        if (isEndOfStream()) {
+            return -1;
+        }
+        skipBytesBeforeOffset();
+        if (shouldLimitLength(len)) {
+            len = (int) (this.maxPos - this.pos);
+        }
+        int bytesRead = this.inputStream.read(b, off, len);
+        if (bytesRead == -1) {
+            return -1;
+        } else {
+            this.pos += bytesRead;
+            return bytesRead;
+        }
+    }
+
+    private boolean isEndOfStream() {
+        return this.maxPos >= 0L && this.pos >= this.maxPos;
+    }
+
+    private boolean shouldLimitLength(int len) {
+        return (this.pos + len > this.maxPos) && this.maxPos != -1;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long toSkip = this.maxPos >= 0L ? Math.min(n, this.maxPos - this.pos) : n;
+        long skippedBytes = this.inputStream.skip(toSkip);
+        this.pos += skippedBytes;
+        return skippedBytes;
+    }
+
+
+    @Override
+    public int available() throws IOException {
+        return this.maxPos >= 0L && this.pos >= this.maxPos ? 0 : this.inputStream.available();
+    }
+
+
+    @Override
+    public String toString() {
+        return this.inputStream.toString();
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        this.inputStream.close();
+    }
+
+
+    @Override
+    public synchronized void reset() throws IOException {
+        this.inputStream.reset();
+        this.pos = this.mark;
+    }
+
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        this.inputStream.mark(readlimit);
+        this.mark = this.pos;
+    }
+
+
+    @Override
+    public boolean markSupported() {
+        return this.inputStream.markSupported();
+    }
+
+    /**
+     * Try skipping bytes to the offset with the internal stream.
+     */
+    private void skipBytesBeforeOffset() throws IOException {
+        final long toSkip = this.minPos - this.pos;
+        if (toSkip > 0) {
+            final long actuallySkipped = this.inputStream.skip(toSkip);
+            this.pos += actuallySkipped;
+            if (actuallySkipped != toSkip) {
+                log.debug("Could not skip {} bytes. Instead skipped {} bytes.", toSkip, actuallySkipped);
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/dnastack/wes/storage/client/local/LocalBlobStorageClientTest.java
+++ b/src/test/java/com/dnastack/wes/storage/client/local/LocalBlobStorageClientTest.java
@@ -4,6 +4,7 @@ import com.dnastack.wes.storage.LocalBlobStorageClient;
 import com.dnastack.wes.storage.LocalBlobStorageClientConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpRange;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -73,7 +74,7 @@ class LocalBlobStorageClientTest {
         Files.write(targetPath, toWrite.getBytes(), StandardOpenOption.CREATE_NEW);
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        storageClient.readBytes(outputStream, targetPath.toString(), 0L, (long) toWrite.length());
+        storageClient.readBytes(outputStream, targetPath.toString(), HttpRange.createByteRange(0L,toWrite.length()));
         String readValue = outputStream.toString();
         Assertions.assertEquals(readValue, toWrite);
 
@@ -90,7 +91,8 @@ class LocalBlobStorageClientTest {
         Files.write(targetPath, toWrite.getBytes(), StandardOpenOption.CREATE_NEW);
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        storageClient.readBytes(outputStream, targetPath.toString(), 5L, (long) toWrite.length());
+
+        storageClient.readBytes(outputStream, targetPath.toString(), HttpRange.createByteRange(5L,toWrite.length()));
         String readValue = outputStream.toString();
         Assertions.assertEquals(toWrite.substring(5), readValue);
     }


### PR DESCRIPTION
This PR adds support for using `Range: bytes=<n>-<n>` header for all log streaming operations