### PR TITLE
[CU-86b9pzqne] Restore github <repositories> block in e2e-tests/pom.xml

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -134,6 +134,18 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <!--
+          Private dependencies hosted in our private github repo are resolved using credentials pulled from settings.xml
+          in cloud build environment. ID of repository must match ID of server in settings.xml
+        -->
+        <repository>
+            <id>github</id>
+            <name>DNAstack Public Github Packages</name>
+            <url>https://maven.pkg.github.com/DNAstack/dnastack-packages</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
PR #38 removed the `<repositories>` block. The Cloud Build e2e image build's offline `mvn process-test-classes` step then fails because the cached `actuator-e2e-test` artifact's `_remote.repositories` origin id (`github`) is no longer in the active build context after `settings.xml` is removed.