### PR TITLE
[CU-86ba2qmju] Fix LocalBlobStorageClient ignoring range request upper bound

### DIFF
--- a/src/main/java/com/dnastack/wes/storage/LocalBlobStorageClient.java
+++ b/src/main/java/com/dnastack/wes/storage/LocalBlobStorageClient.java
@@ -83,6 +83,7 @@ public class LocalBlobStorageClient implements BlobStorageClient {
         long rangeEnd = fileToRead.length();
         if (httpRange != null) {
             rangeStart = httpRange.getRangeStart(fileToRead.length());
+            rangeEnd = httpRange.getRangeEnd(fileToRead.length()) + 1;
         }
 
         try (FileChannel channel = new RandomAccessFile(fileToRead, "r").getChannel()) {


### PR DESCRIPTION
rangeEnd was never updated when an HttpRange was provided, so readBytes()
always read from rangeStart to end-of-file instead of honouring the
requested byte range. GcpBlobStorageClient and AzureBlobStorageClient
both correctly compute rangeEnd; this brings LocalBlobStorageClient in
line with those implementations.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
