### PR TITLE
[CU-86badxec2] Helmify cromwell-wes-service

### DIFF
--- a/.github/workflows/concourse-build-check.yml
+++ b/.github/workflows/concourse-build-check.yml
@@ -1,0 +1,16 @@
+name: Concourse Build Check
+
+on:
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  concourse-build-check:
+    name: Concourse Build Check
+    uses: DNAstack/dnastack-development-tools/.github/workflows/concourse-build-check.yml@b8f171d57cc310232a18ac2028e8ed3ee68eabce
+    with:
+      pipeline_name: 'workbench-alpha'
+      job_name: 'cromwell-wes-service-deploy-helm'
+      concourse_username: ${{ vars.CONCOURSE_USERNAME }}
+    secrets:
+      concourse_password: ${{ secrets.CONCOURSE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ target/
 /.nb-gradle/
 
 */dependency-reduced-pom.xml
+
+# Helm — all regenerated at build time via `helm dep update` / `helm unittest`
+helm/charts/
+helm/Chart.lock
+helm/.debug/
+helm/tests/__snapshot__/

--- a/ci/build-docker-cloud-init-image
+++ b/ci/build-docker-cloud-init-image
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+function validate_arg() {
+  local name=${1}
+  local value=${2}
+
+  if [ -z ${value} ]; then
+    echo "Must specify value for ${name}." >&2
+    exit 1
+  else
+    echo -n ${value}
+  fi
+}
+
+set -e
+set -x
+
+# This script runs the maven build, including unit tests, assembles a fat jar with
+# embedded web server, and packages the resulting thing in a Docker image that runs
+# the server on startup. The image is tagged with the string passed in as the first argument.
+
+# This script is invoked during CI build with the following arguments:
+target_image_name=$(validate_arg "target image name" ${1})
+app_name=$(validate_arg "app name" ${2})
+app_version=$(validate_arg "app version" ${3})
+cloud_init_version=$(validate_arg "cloud init version" ${4})
+
+
+docker build \
+  --build-arg APP_NAME=${app_name} \
+  --build-arg APP_VERSION=${app_version} \
+  --build-arg CLOUD_INIT_VERSION=${cloud_init_version} \
+  -t ${target_image_name} \
+  cloud-init-docker

--- a/cloud-init-docker/Dockerfile
+++ b/cloud-init-docker/Dockerfile
@@ -1,0 +1,4 @@
+ARG CLOUD_INIT_VERSION=NOT_A_REAL_VERSION
+FROM gcr.io/dnastack-container-store/cloud-deployment-scripts:$CLOUD_INIT_VERSION
+
+ADD cloud-init /cloud-init

--- a/cloud-init-docker/cloud-init/apps/cromwell-wes-service/cloud-init
+++ b/cloud-init-docker/cloud-init/apps/cromwell-wes-service/cloud-init
@@ -2,24 +2,16 @@
 # PROVIDE: cromwell-wes-service
 
 set -e
-set -x
+conditionallyEnableDebugLogging
 
-# Set up the WES application database user.
 setupAppDatabase
 
-# Set up the Cromwell database user. The cromwell-db-credentials Secret is
-# chart-managed (lookup+keep pattern) and contains a pre-generated password.
-# We read that password here so cloud-init and the Cromwell container agree on
-# the same credentials rather than each generating their own random value.
 CROMWELL_CREDS_SECRET="${APP_NAME}-cromwell-db-credentials"
 CROMWELL_DB_PASSWORD=$(kubectl get secret "${CROMWELL_CREDS_SECRET}" \
   -n "${NAMESPACE}" \
   -o jsonpath='{.data.password}' | base64 -d)
 setupAppDatabase "${SHARED_POSTGRES_INSTANCE}" cromwell "cromwell" "${CROMWELL_DB_PASSWORD}" "${CROMWELL_CREDS_SECRET}"
 
-# Validate that the pre-configured GCP service account secrets exist.
-# These are not created by the chart — they must be provisioned externally.
-validatePreconfiguredSecret "${APP_NAME}-gcp-credentials" \
-  "Must create GCP Service account for WES to access cloud storage"
+validatePreconfiguredSecret "${APP_NAME}-gcp-credentials" "Must create GCP Service account for WES to access cloud storage"
 labelSecret "${APP_NAME}-gcp-credentials" "app=${APP_NAME}"
 labelSecret "${APP_NAME}-gcp-credentials" "type=app_service-account"

--- a/cloud-init-docker/cloud-init/apps/cromwell-wes-service/cloud-init
+++ b/cloud-init-docker/cloud-init/apps/cromwell-wes-service/cloud-init
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PROVIDE: cromwell-wes-service
+
+set -e
+set -x
+
+# Set up the WES application database user.
+setupAppDatabase
+
+# Set up the Cromwell database user. The cromwell-db-credentials Secret is
+# chart-managed (lookup+keep pattern) and contains a pre-generated password.
+# We read that password here so cloud-init and the Cromwell container agree on
+# the same credentials rather than each generating their own random value.
+CROMWELL_CREDS_SECRET="${APP_NAME}-cromwell-db-credentials"
+CROMWELL_DB_PASSWORD=$(kubectl get secret "${CROMWELL_CREDS_SECRET}" \
+  -n "${NAMESPACE}" \
+  -o jsonpath='{.data.password}' | base64 -d)
+setupAppDatabase "${SHARED_POSTGRES_INSTANCE}" cromwell "cromwell" "${CROMWELL_DB_PASSWORD}" "${CROMWELL_CREDS_SECRET}"
+
+# Validate that the pre-configured GCP service account secrets exist.
+# These are not created by the chart — they must be provisioned externally.
+validatePreconfiguredSecret "${APP_NAME}-gcp-credentials" \
+  "Must create GCP Service account for WES to access cloud storage"
+labelSecret "${APP_NAME}-gcp-credentials" "app=${APP_NAME}"
+labelSecret "${APP_NAME}-gcp-credentials" "type=app_service-account"

--- a/cloud-init-docker/cloud-init/run_cloud_init.sh
+++ b/cloud-init-docker/cloud-init/run_cloud_init.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+export CLOUD_INIT_DIR="$(dirname "$0")"
+export K8S_CLUSTER_API_URL="${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
+
+kubectl config set-cluster ${NAMESPACE} --server=${K8S_CLUSTER_API_URL}
+kubectl config set-context ${NAMESPACE} --namespace=${NAMESPACE}
+kubectl config use-context ${NAMESPACE}
+
+# Skip version control assertion in cloud-init with this file
+touch offline.txt
+
+"${CLOUD_INIT_DIR}"/scripts/cloud-init.sh "${NAMESPACE}" "${APP_NAME}"

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,16 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.svn/
+*.swp
+*.tmp
+*.orig
+*.bak
+*~
+.idea/
+.vscode/
+# helm-unittest sources
+/tests/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: cromwell-wes-service
+description: Helm chart for the DNAstack Cromwell WES Service
+type: application
+version: 0.1.0
+
+dependencies:
+  - name: workbench-helm-library
+    version: 0.5.0-0-ga2566e1
+    repository: oci://us-central1-docker.pkg.dev/dnastack-container-store/helm-charts

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,449 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cromwellwesservice
+{{- if (coalesce .Values.image.secretName ((.Values.global).image).secretName) }}
+imagePullSecrets:
+  - name: "{{ coalesce .Values.image.secretName ((.Values.global).image).secretName }}"
+{{- end }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cromwellwesservice-{{ .Release.Namespace }}-edit-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: cromwellwesservice
+    namespace: {{ .Release.Namespace }}
+
+---
+
+# ConfigMap containing the Cromwell HOCON configuration. Non-secret values are
+# templated directly by Helm. DB credentials (CROMWELL_DB_USER / CROMWELL_DB_PASSWORD)
+# are kept as HOCON substitution references; Typesafe Config resolves them from the
+# environment variables injected by the cromwell container's secretKeyRef entries.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cromwell-wes-service-cromwell-config
+  labels:
+    app: cromwell-wes-service
+    configVersion: {{ .Values.app.configVersion }}
+data:
+  cromwell.conf: |
+    webservice {
+      port = 8000
+      interface = 0.0.0.0
+      binding-timeout = 5s
+    }
+
+    akka.http.server.request-timeout = 60s
+
+    system {
+      new-workflow-poll-rate = 5
+      io {
+        number-of-requests = 500000
+        per = 100 seconds
+        number-of-attempts = 10
+      }
+
+      max-concurrent-workflows = 10000
+      workflow-restart = true
+    }
+
+    google {
+      application-name = "cromwell"
+      auths = [
+        {
+          name = "cromwell-service-account"
+          scheme = "application_default"
+        }
+      ]
+    }
+
+    engine {
+      filesystems {
+        gcs {
+          auth = "cromwell-service-account"
+        }
+        local {
+          enabled: false
+        }
+        http {
+          enabled: true
+        }
+      }
+    }
+
+    call-caching {
+      enabled = true
+    }
+
+    backend {
+      default = "GCPBatch"
+      providers {
+        GCPBatch {
+          actor-factory = "cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory"
+          config {
+            project = {{ .Values.app.cromwell.gcpExecutionProject | quote }}
+            root = {{ .Values.app.cromwell.gcpBucket | quote }}
+
+            maximum-polling-interval = 600
+
+            batch {
+              auth = "cromwell-service-account"
+              location: "{{ coalesce ((.Values.global).cloud).region "us-central1" }}"
+            }
+
+            filesystems {
+              gcs {
+                auth = "cromwell-service-account"
+                project = {{ .Values.app.cromwell.gcpExecutionProject | quote }}
+              }
+              http {}
+            }
+
+            pipeline-timeout = 28 days
+
+            default-runtime-attributes {
+              cpu: 1
+              failOnStderr: false
+              continueOnReturnCode: 0
+              memory: "2 GB"
+              bootDiskSizeGb: 10
+              disks: "local-disk 10 SSD"
+              noAddress: false
+              preemptible: 0
+              docker: "ubuntu:latest"
+              zones: [{{ .Values.app.cromwell.gcpZone | quote }}]
+            }
+          }
+        }
+      }
+    }
+
+    database {
+      profile = "slick.jdbc.PostgresProfile$"
+      db {
+        url = "jdbc:postgresql://{{ coalesce .Values.app.cromwell.postgresInternalHost ((.Values.global).database.postgres).internalHost "postgres" }}/cromwell?rewriteBatchedStatements=true&useSSL=false"
+        user = ${CROMWELL_DB_USER}
+        password = ${CROMWELL_DB_PASSWORD}
+        driver = "org.postgresql.Driver"
+        connectionTimeout = 5000
+      }
+    }
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cromwell-wes-service
+  labels:
+    app: cromwell-wes-service
+    configVersion: {{ .Values.app.configVersion }}
+    secretsHash: {{ .Values.app.secretHash }}
+    product: "workbench"
+    {{- range $key, $value := .Values.global.deploymentLabels }}
+    {{ tpl ($key | toString) $ }}: {{ tpl ($value | toString) $ | quote }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      app: cromwell-wes-service
+      configVersion: {{ .Values.app.configVersion }}
+      secretsHash: {{ .Values.app.secretHash }}
+  template:
+    metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
+        {{- range $key, $value := .Values.global.templateAnnotations }}
+        {{ tpl ($key | toString) $ }}: {{ tpl ($value | toString) $ | quote }}
+        {{- end }}
+      labels:
+        app: cromwell-wes-service
+        version: '{{- include "dnastack.app.version" . }}'
+        configVersion: {{ .Values.app.configVersion }}
+        secretsHash: {{ .Values.app.secretHash }}
+        product: "workbench"
+        {{- range $key, $value := .Values.global.templateLabels }}
+        {{ tpl ($key | toString) $ }}: {{ tpl ($value | toString) $ | quote }}
+        {{- end }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - cromwell-wes-service
+              topologyKey: topology.kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: cromwellwesservice
+      initContainers:
+        - name: cromwell-wes-service-cloud-init
+          image: "{{ coalesce .Values.image.repository ((.Values.global).image).repository }}/cromwell-wes-service-cloud-init-job:{{- include "dnastack.cloudinit.version" . }}"
+          command: [ "/cloud-init/run_cloud_init.sh" ]
+          args: []
+          env:
+            - name: APP_NAME
+              value: 'cromwell-wes-service'
+            - name: VALUES_HASH
+              value: '{{ .Values | toYaml | sha256sum }}'
+            - name: CLOUD_INIT_VERSION
+              value: '{{- include "dnastack.cloudinit.version" . }}'
+            - name: DEPLOYMENT_ROOT_DIR
+              value: '/cloud-init'
+            - name: NAMESPACE
+              value: '{{ coalesce .Values.cloud.clusterNamespace ((.Values.global).cloud).clusterNamespace }}'
+            - name: CONFIG_VERSION
+              value: '{{ .Values.app.configVersion }}'
+            - name: SKIP_FILE_CONFIGS
+              value: "true"
+            - name: SKIP_REPO_CHECK
+              value: "true"
+            - name: SKIP_WALLET_INIT
+              value: "true"
+            - name: USE_LOCAL_HTTPIE
+              value: "true"
+            - name: USE_LOCAL_PSQL
+              value: "true"
+            - name: REPLICA_COUNT
+              value: "1"
+            - name: SHARED_POSTGRES_INSTANCE
+              value: '{{ coalesce .Values.database.postgresInstance (((.Values.global).database).postgres).instance }}'
+            - name: APP_POSTGRES_VERSION
+              value: '{{ coalesce .Values.database.postgresVersion (((.Values.global).database).postgres).version }}'
+            - name: USE_USER_TOKEN_FOR_ADMIN_ACTIONS
+              value: "false"
+            - name: APP_WORKSPACES_WES_HOSTNAME
+              value: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+            - name: WALLET_URL
+              value: '{{- include "dnastack.wallet.internalUrl" . }}'
+            - name: WALLET_RESOURCE
+              value: '{{- include "dnastack.wallet.resourceUrl" . }}/'
+            - name: WALLET_ADMIN_KUBEKEY
+              value: 'wallet-cloud-init-client-credentials'
+          envFrom:
+            - configMapRef:
+                name: cloud-init-env-vars
+                optional: true
+
+      containers:
+        - name: cromwell-wes-service
+          image: "{{ coalesce .Values.image.repository ((.Values.global).image).repository }}/cromwell-wes-service:{{- include "dnastack.app.version" . }}"
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            limits:
+              memory: {{ .Values.app.memoryLimit }}
+            requests:
+              memory: {{ .Values.app.memoryLimit }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 90
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 2
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 20
+            timeoutSeconds: 2
+            failureThreshold: 15
+          env:
+            - name: JAVA_OPTS
+              value: "-XX:+ExitOnOutOfMemoryError -XX:+PrintFlagsFinal"
+            - name: ESTIMATED_THREADS
+              value: "220"
+            - name: ESTIMATED_LOADED_CLASSES
+              value: "28000"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "default,cloud{{ if .Values.app.spring.additionalProfiles }},{{ .Values.app.spring.additionalProfiles }}{{ end }}"
+            - name: SERVER_PORT
+              value: "8080"
+            - name: INFO_APP_NAME
+              value: "WES on Cromwell/GCP"
+            - name: WES_URL
+              value: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+            - name: WES_CROMWELL_URL
+              value: {{ .Values.app.cromwell.cromwellUrl | default "http://localhost:8000" | quote }}
+            - name: WES_BLOBSTORAGECLIENT_NAME
+              value: "GCP"
+            - name: WES_BLOBSTORAGECLIENT_GCP_SERVICEACCOUNTJSON
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.gcpCredentialsSecretName | default "cromwell-wes-service-gcp-credentials" | quote }}
+                  key: service-account
+            - name: WES_BLOBSTORAGECLIENT_GCP_PROJECT
+              value: '{{ coalesce ((.Values.global).cloud.gcloud).project ((.Values.global).cloud).project "" }}'
+            - name: WES_BLOBSTORAGECLIENT_GCP_STAGINGLOCATION
+              value: {{ .Values.app.cromwell.gcpStagingLocation | quote }}
+            - name: INFO_APP_VERSION
+              value: '{{- include "dnastack.app.version" . }}'
+            - name: WES_AUTH_ISSUERURI
+              value: '{{- include "dnastack.wallet.externalUrl" . }}'
+            - name: MANAGEMENT_METRICS_TAGS_REGION
+              value: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+            - name: WES_REGISTRY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "cromwell-wes-service-public-client-credentials"
+                  key: clientId
+            - name: WES_REGISTRY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "cromwell-wes-service-public-client-credentials"
+                  key: clientSecret
+            - name: SPRING_APPLICATION_JSON
+              value: |
+                {
+                  "wes": {
+                    "cromwell": {
+                      "defaultWorkflowOptions": {
+                        "delete_intermediate_output_files": true,
+                        "write_to_cache": false,
+                        "read_from_cache": false,
+                        "default_runtime_attributes": {
+                          "docker": "ubuntu:latest",
+                          "cpu": 1,
+                          "memory": "2 GB",
+                          "bootDiskSizeGb": 10,
+                          "disks": "local-disk 10 SSD"
+                        }
+                      }
+                    }
+                  }
+                }
+            - name: DD_PROFILING_ENABLED
+              value: "false"
+            - name: DD_APPSEC_ENABLED
+              value: "false"
+            - name: DD_TRACE_PROPAGATION_STYLE
+              value: "datadog,b3single,b3multi"
+            - name: DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+              value: "400"
+            - name: DD_PROFILING_JFR_TEMPLATE_OVERRIDE_FILE
+              value: minimal
+            {{- include "mergeEnvLists" (dict "lists" (list .Values.env .Values.global.instrumentation.env) "template" $) | nindent 12 }}
+
+        - name: cromwell
+          image: "broadinstitute/cromwell:{{ .Values.app.cromwell.imageVersion | default "89" }}"
+          resources:
+            limits:
+              memory: "4700Mi"
+            requests:
+              memory: "4700Mi"
+          ports:
+            - name: cromwell-http
+              containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /engine/v1/status
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /engine/v1/status
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 30
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /engine/v1/status
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 20
+          env:
+            - name: CROMWELL_ARGS
+              value: "server"
+            - name: JAVA_OPTS
+              value: "-XX:+ExitOnOutOfMemoryError -XX:+PrintFlagsFinal -DLOG_LEVEL=WARN -Dconfig.file=/configuration/cromwell.conf -XX:MaxMetaspaceSize=715M -XX:ReservedCodeCacheSize=240M -Xss1M -Xmx3151836K"
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/secrets/cromwell/key.json"
+            # These env vars are resolved by Typesafe Config (HOCON) substitution at startup,
+            # satisfying the ${CROMWELL_DB_USER} / ${CROMWELL_DB_PASSWORD} references in cromwell.conf.
+            - name: CROMWELL_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.cromwell.dbCredentialsSecretName | default "cromwell-wes-service-cromwell-db-credentials" | quote }}
+                  key: username
+            - name: CROMWELL_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.cromwell.dbCredentialsSecretName | default "cromwell-wes-service-cromwell-db-credentials" | quote }}
+                  key: password
+            - name: DD_APM_ENABLED
+              value: "true"
+            - name: DD_PROFILING_ENABLED
+              value: "false"
+            - name: DD_APPSEC_ENABLED
+              value: "false"
+            - name: DD_SERVICE
+              value: "cromwell-wes-service-cromwell"
+            - name: DD_VERSION
+              value: '{{- include "dnastack.app.version" . }}'
+          volumeMounts:
+            - mountPath: "/secrets/cromwell/key.json"
+              name: cromwell-sa
+              subPath: service-account
+            - mountPath: "/configuration/cromwell.conf"
+              subPath: cromwell.conf
+              name: cromwell-config
+
+      volumes:
+        - name: cromwell-sa
+          secret:
+            secretName: {{ .Values.app.cromwell.saSecretName | default "cromwell-wes-service-cromwell-credentials" | quote }}
+        - name: cromwell-config
+          configMap:
+            name: cromwell-wes-service-cromwell-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cromwell-wes-service
+  labels:
+    name: cromwell-wes-service
+spec:
+  selector:
+    app: cromwell-wes-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/helm/templates/resources/app.yaml
+++ b/helm/templates/resources/app.yaml
@@ -1,0 +1,204 @@
+# ==============================================================================
+# cromwell-wes-service client credentials (Secret + WalletClient)
+# ==============================================================================
+{{- $clientSecretObj := (lookup "v1" "Secret" .Release.Namespace "cromwell-wes-service-client-credentials") | default dict }}
+{{- if or (empty $clientSecretObj)
+          (and
+            (hasKey $clientSecretObj.metadata "annotations")
+            (hasKey $clientSecretObj.metadata.annotations "meta.helm.sh/release-name")
+            (eq (get $clientSecretObj.metadata.annotations "meta.helm.sh/release-name") .Release.Name))
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cromwell-wes-service-client-credentials
+  labels:
+    app: cromwell-wes-service
+    type: app_wallet-client-credential
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- $clientSecretData := (get $clientSecretObj "data") | default dict }}
+  {{- $clientSecret := (get $clientSecretData "clientSecret") | default (randBytes 32 | b64dec | printf "%x" | b64enc) }}
+  clientId: {{ b64enc "cromwell-wes-service" | quote }}
+  clientSecret: {{ $clientSecret | quote }}
+{{- end }}
+
+---
+
+# ==============================================================================
+# cromwell-wes-service-public client credentials (Secret + WalletClient)
+# Used by ewes-service for device_code flows.
+# ==============================================================================
+{{- $publicSecretObj := (lookup "v1" "Secret" .Release.Namespace "cromwell-wes-service-public-client-credentials") | default dict }}
+{{- if or (empty $publicSecretObj)
+          (and
+            (hasKey $publicSecretObj.metadata "annotations")
+            (hasKey $publicSecretObj.metadata.annotations "meta.helm.sh/release-name")
+            (eq (get $publicSecretObj.metadata.annotations "meta.helm.sh/release-name") .Release.Name))
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cromwell-wes-service-public-client-credentials
+  labels:
+    app: cromwell-wes-service
+    type: app_wallet-client-credential
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- $publicSecretData := (get $publicSecretObj "data") | default dict }}
+  {{- $publicSecret := (get $publicSecretData "clientSecret") | default (randBytes 32 | b64dec | printf "%x" | b64enc) }}
+  clientId: {{ b64enc "cromwell-wes-service-public" | quote }}
+  clientSecret: {{ $publicSecret | quote }}
+{{- end }}
+
+---
+
+# ==============================================================================
+# cromwell-wes-service-cromwell-db-credentials
+# Password is generated once on first install and preserved on upgrades via
+# helm.sh/resource-policy: keep. Cloud-init reads this secret and creates the
+# Cromwell Postgres user with the stored password. Cromwell container reads these
+# credentials at startup via CROMWELL_DB_USER / CROMWELL_DB_PASSWORD env vars.
+# ==============================================================================
+{{- $cromwellDbSecretObj := (lookup "v1" "Secret" .Release.Namespace "cromwell-wes-service-cromwell-db-credentials") | default dict }}
+{{- if or (empty $cromwellDbSecretObj)
+          (and
+            (hasKey $cromwellDbSecretObj.metadata "annotations")
+            (hasKey $cromwellDbSecretObj.metadata.annotations "meta.helm.sh/release-name")
+            (eq (get $cromwellDbSecretObj.metadata.annotations "meta.helm.sh/release-name") .Release.Name))
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cromwell-wes-service-cromwell-db-credentials
+  labels:
+    app: cromwell-wes-service
+    type: cromwell-db-credential
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- $cromwellDbSecretData := (get $cromwellDbSecretObj "data") | default dict }}
+  {{- $cromwellDbPassword := (get $cromwellDbSecretData "password") | default (randBytes 32 | b64dec | printf "%x" | b64enc) }}
+  username: {{ b64enc "cromwell" | quote }}
+  password: {{ $cromwellDbPassword | quote }}
+{{- end }}
+
+---
+
+# ==============================================================================
+# WalletClient: cromwell-wes-service
+# ==============================================================================
+apiVersion: dnastack.com/v1
+kind: WalletClient
+metadata:
+  name: cromwell-wes-service
+  labels:
+    app: cromwell-wes-service
+spec:
+  syncMode: CREATE_AND_UPDATE
+  clientSecrets:
+    - credentialId: default
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-client-credentials
+        key: clientSecret
+    - credentialId: rotation-backup
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-client-credentials
+        key: clientSecret
+  data:
+    id: cromwell-wes-service
+    name: "OAuth client for cromwell-wes-service"
+    grants:
+      - audience: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+        grantTypes:
+          - client_credentials
+        responseTypes:
+          - token
+        scopes:
+          - name: wes
+
+---
+
+# ==============================================================================
+# WalletClient: cromwell-wes-service-public
+# Public client used by ewes-service for device_code flows.
+# ==============================================================================
+apiVersion: dnastack.com/v1
+kind: WalletClient
+metadata:
+  name: cromwell-wes-service-public
+  labels:
+    app: cromwell-wes-service
+spec:
+  syncMode: CREATE_AND_UPDATE
+  clientSecrets:
+    - credentialId: default
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-public-client-credentials
+        key: clientSecret
+    - credentialId: rotation-backup
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-public-client-credentials
+        key: clientSecret
+  data:
+    id: cromwell-wes-service-public
+    name: "Public OAuth client for cromwell-wes-service (device code flows)"
+    grants:
+      - audience: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+        # sensitive: true is load-bearing here — these scopes appear in the device_code consent UI
+        grantTypes:
+          - "urn:ietf:params:oauth:grant-type:device_code"
+          - refresh_token
+        responseTypes:
+          - code
+          - token
+        scopes:
+          - name: wes
+          - name: offline_access
+          - name: openid
+            sensitive: true
+          - name: profile
+            sensitive: true
+          - name: email
+            sensitive: true
+
+---
+
+# ==============================================================================
+# WalletPolicy: cromwell-wes-service-policy
+# ==============================================================================
+apiVersion: dnastack.com/v1
+kind: WalletPolicy
+metadata:
+  name: cromwell-wes-service-policy
+  labels:
+    app: cromwell-wes-service
+spec:
+  syncMode: CREATE_AND_UPDATE
+  data:
+    id: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+    name: Access Policy for cromwell-wes-service
+    statements:
+      - principals:
+          - type: service
+            id: cromwell-wes-service
+          - type: service
+            id: cromwell-wes-service-e2e-test
+          - type: group
+            id: dnastack-devs-external
+        actions:
+          - wes:runs:read
+          - wes:runs:write
+          - wes:runs:cancel
+          - wes:execute
+        resources:
+          - uri: '{{- include "dnastack.cromwellWesService.externalUrl" . }}/'

--- a/helm/templates/resources/app.yaml
+++ b/helm/templates/resources/app.yaml
@@ -185,7 +185,7 @@ metadata:
 spec:
   syncMode: CREATE_AND_UPDATE
   data:
-    id: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+    id: cromwell-wes-service-policy
     name: Access Policy for cromwell-wes-service
     statements:
       - principals:

--- a/helm/templates/resources/e2e-test.yaml
+++ b/helm/templates/resources/e2e-test.yaml
@@ -1,0 +1,59 @@
+# ==============================================================================
+# cromwell-wes-service-e2e-test client (Secret + WalletClient + WalletPolicy)
+# ==============================================================================
+{{- $e2eSecretObj := (lookup "v1" "Secret" .Release.Namespace "cromwell-wes-service-e2e-test-client-credentials") | default dict }}
+{{- if or (empty $e2eSecretObj)
+          (and
+            (hasKey $e2eSecretObj.metadata "annotations")
+            (hasKey $e2eSecretObj.metadata.annotations "meta.helm.sh/release-name")
+            (eq (get $e2eSecretObj.metadata.annotations "meta.helm.sh/release-name") .Release.Name))
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cromwell-wes-service-e2e-test-client-credentials
+  labels:
+    app: cromwell-wes-service
+    type: test_wallet-client-credential
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- $e2eSecretData := (get $e2eSecretObj "data") | default dict }}
+  {{- $e2eClientSecret := (get $e2eSecretData "clientSecret") | default (randBytes 32 | b64dec | printf "%x" | b64enc) }}
+  clientId: {{ b64enc "cromwell-wes-service-e2e-test" | quote }}
+  clientSecret: {{ $e2eClientSecret | quote }}
+{{- end }}
+
+---
+
+apiVersion: dnastack.com/v1
+kind: WalletClient
+metadata:
+  name: cromwell-wes-service-e2e-test
+  labels:
+    app: cromwell-wes-service
+spec:
+  syncMode: CREATE_AND_UPDATE
+  clientSecrets:
+    - credentialId: default
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-e2e-test-client-credentials
+        key: clientSecret
+    - credentialId: rotation-backup
+      syncMode: CREATE_ONLY
+      secretKeyRef:
+        name: cromwell-wes-service-e2e-test-client-credentials
+        key: clientSecret
+  data:
+    id: cromwell-wes-service-e2e-test
+    name: "Client for end-to-end testing of cromwell-wes-service"
+    grants:
+      - audience: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+        grantTypes:
+          - client_credentials
+        responseTypes:
+          - token
+        scopes:
+          - name: wes

--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -1,0 +1,17 @@
+{{- if (coalesce .Values.ingressRoute.enabled ((.Values.global).ingressRoutes).enabled) -}}
+{{- $spaceDnsName := coalesce .Values.cloud.spaceDnsName ((.Values.global).cloud).spaceDnsName -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cromwell-wes-service-ingress-route
+  namespace: "{{ coalesce .Values.cloud.clusterNamespace ((.Values.global).cloud).clusterNamespace }}"
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`{{ include "dnastack.externalHostname" (dict "Values" .Values "Template" .Template "name" "cromwellWesService") }}`)
+      kind: Rule
+      services:
+        - name: cromwell-wes-service
+          port: 8080
+{{- end }}

--- a/helm/templates/tests/e2etests.yaml
+++ b/helm/templates/tests/e2etests.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "cromwell-wes-service-e2etest"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: cromwellwesservice
+      restartPolicy: Never
+      containers:
+        - name: "cromwell-wes-service-e2etest"
+          image: "{{ coalesce .Values.image.repository ((.Values.global).image).repository }}/cromwell-wes-service-e2e-tests:{{ .Chart.Version }}"
+          env:
+            - name: _JAVA_OPTIONS
+              value: "-Dlogging.level.root=TRACE"
+            - name: E2E_BASE_URI
+              value: '{{- include "dnastack.cromwellWesService.internalUrl" . }}'
+            - name: E2E_CLIENT_RESOURCE_BASE_URI
+              value: '{{- include "dnastack.cromwellWesService.externalUrl" . }}'
+            - name: E2E_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: clientId
+                  name: cromwell-wes-service-e2e-test-client-credentials
+            - name: E2E_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: clientSecret
+                  name: cromwell-wes-service-e2e-test-client-credentials
+            - name: E2E_TOKEN_URI
+              value: '{{- include "dnastack.wallet.internalUrl" . }}/oauth/token'
+            - name: E2E_WALLET_BASE_URI
+              value: '{{- include "dnastack.wallet.externalUrl" . }}'
+            - name: E2E_WALLET_TOKEN_URI
+              value: '{{- include "dnastack.wallet.internalUrl" . }}/oauth/token'
+            - name: E2E_WALLET_AUDIENCE
+              value: '{{- include "dnastack.cromwellWesService.resourceUrl" . }}'
+            - name: E2E_WALLET_RESOURCE
+              value: '{{- include "dnastack.cromwellWesService.resourceUrl" . }}/'
+            - name: E2E_ACTUATOR_INFO_NAME
+              value: "cromwell-wes-service"
+            - name: E2E_TEST_OBJECT_TRANSFER
+              value: "false"
+      {{- if .Values.test.keepalive.enabled }}
+          volumeMounts:
+            - mountPath: "/target"
+              name: "reports"
+        - name: "keepalive"
+          image: "busybox"
+          command: ["/bin/sh", "-c", "sleep {{ .Values.test.keepalive.duration }}"]
+          volumeMounts:
+            - mountPath: "/target"
+              name: "reports"
+      volumes:
+        - name: "reports"
+          emptyDir: {}
+      {{- end }}

--- a/helm/templates/zz_required.yaml
+++ b/helm/templates/zz_required.yaml
@@ -1,0 +1,12 @@
+# Named zz_required.yaml so it processes last (reverse-alphabetical order), running
+# the value-gate after all other templates have been evaluated.
+{{- $_ := required "image.repository is a required value" (coalesce .Values.image.repository ((.Values.global).image).repository) }}
+{{- $_ = required "app.configVersion is a required value" .Values.app.configVersion }}
+{{- $_ = required "database.postgresVersion is a required value" (coalesce .Values.database.postgresVersion (((.Values.global).database).postgres).version) }}
+{{- $_ = required "database.postgresInstance is a required value" (coalesce .Values.database.postgresInstance (((.Values.global).database).postgres).instance) }}
+{{- $_ = required "cloud.clusterNamespace is a required value" (coalesce .Values.cloud.clusterNamespace ((.Values.global).cloud).clusterNamespace) }}
+{{- $_ = required "cloud.clusterName is a required value" (coalesce .Values.cloud.clusterName ((.Values.global).cloud).clusterName) }}
+{{- $_ = required "cloud.spaceDnsName is a required value" (coalesce .Values.cloud.spaceDnsName ((.Values.global).cloud).spaceDnsName) }}
+{{- $_ = required "app.cromwell.gcpExecutionProject is a required value" .Values.app.cromwell.gcpExecutionProject }}
+{{- $_ = required "app.cromwell.gcpBucket is a required value" .Values.app.cromwell.gcpBucket }}
+{{- $_ = required "app.cromwell.gcpStagingLocation is a required value" .Values.app.cromwell.gcpStagingLocation }}

--- a/helm/tests/chart_deployment_test.yaml
+++ b/helm/tests/chart_deployment_test.yaml
@@ -1,0 +1,217 @@
+suite: Deployment shape tests
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: renders expected resource kinds
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          any: true
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          any: true
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+          any: true
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          any: true
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+          any: true
+
+  - it: Deployment has two main containers
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: cromwell-wes-service
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: cromwell
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[1].ports[0].containerPort
+          value: 8000
+
+  - it: Deployment has cloud-init init container
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: cromwell-wes-service-cloud-init
+
+  - it: Deployment has SKIP_WALLET_INIT true in cloud-init
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SKIP_WALLET_INIT
+            value: "true"
+
+  - it: cromwell container mounts GCP SA secret
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cromwell-sa
+            secret:
+              secretName: cromwell-wes-service-cromwell-credentials
+
+  - it: respects configurable SA secret name
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+      app.cromwell.saSecretName: workspaces-wes-cromwell-credentials
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cromwell-sa
+            secret:
+              secretName: workspaces-wes-cromwell-credentials
+
+  - it: cromwell container reads DB credentials from secret
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: CROMWELL_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: cromwell-wes-service-cromwell-db-credentials
+                key: username
+
+  - it: replicas defaults to 1
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: IngressRoute not rendered when ingressRoute.enabled is false
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+      ingressRoute.enabled: false
+    asserts:
+      - notFailedTemplate: {}

--- a/helm/tests/chart_e2etests_test.yaml
+++ b/helm/tests/chart_e2etests_test.yaml
@@ -1,0 +1,80 @@
+suite: E2E test Job tests
+templates:
+  - templates/tests/e2etests.yaml
+tests:
+  - it: renders e2e test Job
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: cromwell-wes-service-e2etest
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+
+  - it: keepalive sidecar absent by default
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: keepalive
+
+  - it: keepalive sidecar present when enabled
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+      test.keepalive.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: keepalive
+            image: busybox
+            command: ["/bin/sh", "-c", "sleep 300"]
+            volumeMounts:
+              - mountPath: "/target"
+                name: "reports"

--- a/helm/tests/chart_resources_app_test.yaml
+++ b/helm/tests/chart_resources_app_test.yaml
@@ -1,0 +1,124 @@
+suite: App resources tests
+templates:
+  - templates/resources/app.yaml
+tests:
+  - it: renders Secrets, WalletClients, and WalletPolicy
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: cromwell-wes-service-client-credentials
+          any: true
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: cromwell-wes-service-public-client-credentials
+          any: true
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: cromwell-wes-service-cromwell-db-credentials
+          any: true
+      - containsDocument:
+          kind: WalletClient
+          apiVersion: dnastack.com/v1
+          name: cromwell-wes-service
+          any: true
+      - containsDocument:
+          kind: WalletClient
+          apiVersion: dnastack.com/v1
+          name: cromwell-wes-service-public
+          any: true
+      - containsDocument:
+          kind: WalletPolicy
+          apiVersion: dnastack.com/v1
+          name: cromwell-wes-service-policy
+          any: true
+
+  - it: cromwell-db-credentials Secret has username cromwell
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: metadata.name
+      value: cromwell-wes-service-cromwell-db-credentials
+    asserts:
+      - equal:
+          path: data.username
+          value: Y3JvbXdlbGw=   # base64("cromwell")
+
+  - it: WalletPolicy resource URI uses external URL
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: metadata.name
+      value: cromwell-wes-service-policy
+    asserts:
+      - equal:
+          path: spec.data.statements[0].resources[0].uri
+          value: 'https://wes.example.com/'
+
+  - it: Secrets have helm.sh/resource-policy keep
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: metadata.name
+      value: cromwell-wes-service-client-credentials
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/helm/tests/chart_resources_e2e_test_test.yaml
+++ b/helm/tests/chart_resources_e2e_test_test.yaml
@@ -1,0 +1,56 @@
+suite: E2E test resources tests
+templates:
+  - templates/resources/e2e-test.yaml
+tests:
+  - it: renders e2e-test Secret and WalletClient
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: cromwell-wes-service-e2e-test-client-credentials
+          any: true
+      - containsDocument:
+          kind: WalletClient
+          apiVersion: dnastack.com/v1
+          name: cromwell-wes-service-e2e-test
+          any: true
+
+  - it: e2e-test Secret clientId is base64 of cromwell-wes-service-e2e-test
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      cromwellWesService.appName: cromwell-wes-service
+      cromwellWesService.externalHostname: wes.example.com
+      wallet.appName: wallet
+      wallet.externalHostname: auth.example.com
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    documentSelector:
+      path: metadata.name
+      value: cromwell-wes-service-e2e-test-client-credentials
+    asserts:
+      - equal:
+          path: data.clientId
+          value: Y3JvbXdlbGwtd2VzLXNlcnZpY2UtZTJlLXRlc3Q=   # base64("cromwell-wes-service-e2e-test")

--- a/helm/tests/chart_zz_required_test.yaml
+++ b/helm/tests/chart_zz_required_test.yaml
@@ -1,0 +1,48 @@
+suite: Required value gate tests
+templates:
+  - templates/zz_required.yaml
+tests:
+  - it: passes with all required values
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: fails without image.repository
+    set:
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpExecutionProject: project
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - failedTemplate:
+          errorMessage: "image.repository is a required value"
+
+  - it: fails without app.cromwell.gcpExecutionProject
+    set:
+      image.repository: gcr.io/dnastack-container-store
+      app.configVersion: cv
+      database.postgresInstance: pg
+      database.postgresVersion: "14"
+      cloud.clusterName: c
+      cloud.clusterNamespace: n
+      cloud.spaceDnsName: d
+      app.cromwell.gcpBucket: gs://bucket
+      app.cromwell.gcpStagingLocation: gs://bucket/staging
+    asserts:
+      - failedTemplate:
+          errorMessage: "app.cromwell.gcpExecutionProject is a required value"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,75 @@
+global:
+  cloud:
+    clusterName:
+    clusterNamespace:
+    spaceDnsName:
+    gcloud:
+      project:
+    region:
+    zone:
+  database:
+    postgres:
+      instance:
+      version:
+      internalHost:   # in-cluster postgres hostname, defaults to "postgres"
+  image:
+    repository:
+    secretName:
+  ingressRoutes:
+    enabled:
+  instrumentation:
+    env:
+
+image:
+  secretName:   # image pull secret for GCP artifact registry
+  repository:   # docker repository to pull images from
+
+ingressRoute:
+  enabled:   # boolean; per-env global-values.yaml flips this on once ready to cut over ingress
+
+app:
+  configVersion: config-version
+  secretHash: secrets-hash
+  memoryLimit: "2048Mi"
+  replicas: 1
+  spring:
+    additionalProfiles: ""
+
+  # Pre-configured GCP credentials secrets. These must exist in the cluster before
+  # deploying. The defaults use the cromwell-wes-service naming; for alpha/preview
+  # cutover from the legacy workspaces-wes deployment, override to the existing names
+  # (e.g. workspaces-wes-gcp-credentials) in the env's global-values.yaml.
+  gcpCredentialsSecretName: cromwell-wes-service-gcp-credentials
+
+  cromwell:
+    imageVersion: "89"   # broadinstitute/cromwell image tag
+    saSecretName: cromwell-wes-service-cromwell-credentials      # GCP SA for Cromwell to access GCS
+    dbCredentialsSecretName: cromwell-wes-service-cromwell-db-credentials  # created by cloud-init
+    gcpExecutionProject: ""   # GCP project where Cromwell batch jobs run (e.g. ardent-window-817)
+    gcpBucket: ""             # GCS bucket for Cromwell outputs (e.g. gs://my-wes-bucket)
+    gcpStagingLocation: ""    # GCS staging location for WES blob storage
+    gcpZone: "us-central1-a"  # GCP zone for Cromwell batch jobs
+    cromwellUrl: "http://localhost:8000"  # in-pod URL to the Cromwell sidecar
+
+cromwellWesService:
+  appName:
+wallet:
+  appName:
+
+database:
+  postgresVersion:
+  postgresInstance:
+
+cloud:
+  clusterNamespace:
+  clusterName:
+  spaceDnsName:
+
+env: []   # extra env merged into main container via mergeEnvLists
+
+test:
+  keepalive:
+    enabled: false
+    # 5 min is enough for the Concourse upload-test-output step to kubectl exec
+    # artifacts out of the test pod. Longer windows silently block helm test reruns.
+    duration: 300


### PR DESCRIPTION
## Summary

- Adds a self-contained Helm chart (`helm/`) for `cromwell-wes-service`, migrating from the legacy `cds-apps` kubectl-deploy pattern
- Two-container Deployment: WES app (port 8080) + Broadinstitute Cromwell sidecar (port 8000) with shared GCP SA volume and `cromwell.conf` ConfigMap
- Chart manages `cromwell-wes-service-cromwell-db-credentials` Secret (lookup+keep) so cloud-init can read the pre-generated password via `setupAppDatabase`
- WalletClient/WalletPolicy CRDs provisioned by chart; cloud-init runs with `SKIP_WALLET_INIT=true`
- IngressRoute gated on `ingressRoute.enabled` for per-env cutover
- Depends on `workbench-helm-library 0.5.0-0-ga2566e1` (new release adding `cromwellWesService` URL helpers)
- Adds `cloud-init-docker/`, `ci/build-docker-cloud-init-image`, and `.github/workflows/concourse-build-check.yml`
- 21 helm-unittest tests, all passing

## Test plan

- [ ] `helm dep update helm/` pulls `workbench-helm-library:0.5.0-0-ga2566e1` cleanly
- [ ] `helm lint helm/` — 0 failures
- [ ] `helm unittest helm/` — 21/21 pass
- [ ] CI builds cloud-init and app images successfully
- [ ] Alpha deploy via `workbench-alpha-pipeline` helm job

🤖 Generated with [Claude Code](https://claude.com/claude-code)