### PR TITLE
[CU-86bah3eha] Migrate @PreAuthorize from coarse wes:* to fine workbench.runs.* actions

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -29,6 +29,8 @@
         <slf4j.version>2.0.18</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jackson.version>2.22.0</jackson.version>
+        <!-- jackson-annotations publishes 2.22 (no patch), not 2.22.0 — pin separately so resolution doesn't fail -->
+        <jackson-annotations.version>2.22</jackson-annotations.version>
         <jfairy.version>0.5.9</jfairy.version>
         <gcloud.version>1.94.0</gcloud.version>
     </properties>
@@ -82,7 +84,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -69,7 +69,7 @@ public class WesV1Controller {
     }
 
 
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:execute', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.execute', 'wes')")
     @PostMapping(value = "/runs", produces = {
         MediaType.APPLICATION_JSON_VALUE
     }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -94,7 +94,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:runs:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.list', 'wes')")
     @GetMapping(path = "/runs", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunListResponse getRuns(
         @RequestParam(value = "page_size", required = false) Integer pageSize,
@@ -104,21 +104,21 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:read")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunLog getRun(@PathVariable("run_id") String runId) {
         return adapter.getRun(runId);
     }
 
     @AuditActionUri("wes:run:status")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}/status", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunStatus getRunStatus(@PathVariable("run_id") String runId) {
         return adapter.getRunStatus(runId);
     }
 
     @AuditActionUri("wes:run:cancel")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:cancel', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.cancel', 'wes')")
     @PostMapping(path = "/runs/{runId}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunId cancelRun(@PathVariable("runId") String runId) {
         return adapter.cancel(runId);
@@ -126,14 +126,14 @@ public class WesV1Controller {
 
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
         adapter.getLogBytes(response.getOutputStream(), runId, RangeHeaderUtils.getRangeFromHeaders(response, headers));
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -145,7 +145,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,
@@ -157,7 +157,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -170,7 +170,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,

--- a/src/main/java/com/dnastack/wes/files/RunFileController.java
+++ b/src/main/java/com/dnastack/wes/files/RunFileController.java
@@ -22,21 +22,21 @@ public class RunFileController {
     public RunFileController(RunFileService runFileService) {this.runFileService = runFileService;}
 
     @AuditActionUri("wes:runs:files:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.list', 'wes')")
     @GetMapping(value = "/runs/{runId}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFiles getRunFiles(@PathVariable String runId) {
         return runFileService.getRunFiles(runId);
     }
 
     @AuditActionUri("wes:runs:files:get-metadata")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFile getRunFile(@PathVariable String runId, @RequestParam String path) {
         return runFileService.getRunFile(runId,path);
     }
 
     @AuditActionUri("wes:runs:files:get-content")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     public void streamFileContents(
         HttpServletResponse response,
@@ -50,7 +50,7 @@ public class RunFileController {
 
 
     @AuditActionUri("wes:run:files:delete")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:write', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.delete', 'wes')")
     @DeleteMapping(value = "/runs/{run_id}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFileDeletions deleteRunFiles(
         @PathVariable("run_id") String runId,


### PR DESCRIPTION
cromwell-wes-service (the raw GA4GH WES wrapper around Cromwell) was the last RBAC Phase 2 holdout
still on coarse actions. Migrate its @PreAuthorize authorization to the fine workbench.runs.*
vocabulary, reusing ewes-service's exact action names for the same GA4GH WES operations. This is a
one-for-one REPLACE: the dnastack-token-validator action set is AND-matched (every required action
must be held), so a {coarse, fine} coexistence annotation is impossible — coexistence lives only on
the grant side during transition.

WesV1Controller:
- POST /runs            -> workbench.runs.execute
- GET  /runs            -> workbench.runs.list
- GET  /runs/{id}       -> workbench.runs.get
- GET  /runs/{id}/status-> workbench.runs.get
- POST /runs/{id}/cancel-> workbench.runs.cancel
- all  /runs/{id}/logs/*-> workbench.runs.logs.get
RunFileController:
- GET    /runs/{id}/files -> workbench.runs.files.list   (new action)
- GET    /runs/{id}/file  -> workbench.runs.files.get     (metadata + content)
- DELETE /runs/{id}/files -> workbench.runs.files.delete  (new action)

service-info and the service-registry /services stay permitAll. @AuditActionUri labels and the
resource paths/scope ('wes') are unchanged (cromwell-wes is NOT namespace-scoped).

The two new actions (workbench.runs.files.list/delete) are added to the WUS namespace role
templates and the :8090 consumer Wallet policies in companion commits (dnastack-development-tools,
workbench-user-service). Deployed grants (development-environment-configuration workspaces-wes
policies.yaml) need the fine actions before this deploys — follow-up.

Unit tests green (17, 0 failures).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
