### PR TITLE
[CU-86bah3eha] Revert fine-grained @PreAuthorize migration (#66) to reland coordinated

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -29,8 +29,6 @@
         <slf4j.version>2.0.18</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jackson.version>2.22.0</jackson.version>
-        <!-- jackson-annotations publishes 2.22 (no patch), not 2.22.0 — pin separately so resolution doesn't fail -->
-        <jackson-annotations.version>2.22</jackson-annotations.version>
         <jfairy.version>0.5.9</jfairy.version>
         <gcloud.version>1.94.0</gcloud.version>
     </properties>
@@ -84,7 +82,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson-annotations.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -69,7 +69,7 @@ public class WesV1Controller {
     }
 
 
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.execute', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:execute', 'wes')")
     @PostMapping(value = "/runs", produces = {
         MediaType.APPLICATION_JSON_VALUE
     }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -94,7 +94,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:runs:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.list', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:runs:read', 'wes')")
     @GetMapping(path = "/runs", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunListResponse getRuns(
         @RequestParam(value = "page_size", required = false) Integer pageSize,
@@ -104,21 +104,21 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:read")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{run_id}", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunLog getRun(@PathVariable("run_id") String runId) {
         return adapter.getRun(runId);
     }
 
     @AuditActionUri("wes:run:status")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{run_id}/status", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunStatus getRunStatus(@PathVariable("run_id") String runId) {
         return adapter.getRunStatus(runId);
     }
 
     @AuditActionUri("wes:run:cancel")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.cancel', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:cancel', 'wes')")
     @PostMapping(path = "/runs/{runId}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunId cancelRun(@PathVariable("runId") String runId) {
         return adapter.cancel(runId);
@@ -126,14 +126,14 @@ public class WesV1Controller {
 
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
         adapter.getLogBytes(response.getOutputStream(), runId, RangeHeaderUtils.getRangeFromHeaders(response, headers));
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -145,7 +145,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,
@@ -157,7 +157,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -170,7 +170,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,

--- a/src/main/java/com/dnastack/wes/files/RunFileController.java
+++ b/src/main/java/com/dnastack/wes/files/RunFileController.java
@@ -22,21 +22,21 @@ public class RunFileController {
     public RunFileController(RunFileService runFileService) {this.runFileService = runFileService;}
 
     @AuditActionUri("wes:runs:files:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.list', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFiles getRunFiles(@PathVariable String runId) {
         return runFileService.getRunFiles(runId);
     }
 
     @AuditActionUri("wes:runs:files:get-metadata")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFile getRunFile(@PathVariable String runId, @RequestParam String path) {
         return runFileService.getRunFile(runId,path);
     }
 
     @AuditActionUri("wes:runs:files:get-content")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     public void streamFileContents(
         HttpServletResponse response,
@@ -50,7 +50,7 @@ public class RunFileController {
 
 
     @AuditActionUri("wes:run:files:delete")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.delete', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:write', 'wes')")
     @DeleteMapping(value = "/runs/{run_id}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFileDeletions deleteRunFiles(
         @PathVariable("run_id") String runId,


### PR DESCRIPTION
Reverts #66 (`634d526` — migrate `@PreAuthorize` coarse `wes:*` → fine `workbench.runs.*`).

Same root cause as the WUS revert (workbench-user-service#149): the fine-grained enforcement shipped before the matching consumer grants, so callers 403. Reverting to restore the working coarse-action state; relands as one coordinated change (enforcement + all consumer grants) on `redo-finegrained-rbac-CU-86bah3eha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)