### PR TITLE
[CU-86bak43nm] Import jackson-bom so jackson-annotations resolves to its real version

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -28,13 +28,25 @@
         <restassured.version>5.5.7</restassured.version>
         <slf4j.version>2.0.18</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.bom.version>2.22.0</jackson.bom.version>
         <jfairy.version>0.5.9</jfairy.version>
         <gcloud.version>1.94.0</gcloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <!--
+                  Jackson modules are versioned individually: jackson-core/jackson-databind ship as 2.22.0
+                  while jackson-annotations ships as 2.22 (no patch segment). The BOM maps each module to its
+                  correct version, so we must not pin a single ${jackson.version} across all three.
+                -->
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured-bom</artifactId>
@@ -72,17 +84,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>


### PR DESCRIPTION
jackson-annotations ships independently as 2.22 (no patch segment) while
jackson-core/databind ship as 2.22.0, so the shared <jackson.version>2.22.0</jackson.version>
property requested a non-existent jackson-annotations:2.22.0. That broke the offline e2e
image build: go-offline 404s on the missing artifact, then the offline process-test-classes
step aborts with "has not been downloaded from it before".

Import the official jackson-bom and let each module inherit its correct per-module version
instead of pinning all three to one property. The BOM is the single source of truth Renovate
can bump cleanly, so it won't reintroduce the skew on the next jackson bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
