### PR TITLE
[CU-86bah3eha] Fine-grained RBAC reland — flag-gated enforcement (default OFF)

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -28,15 +28,25 @@
         <restassured.version>5.5.7</restassured.version>
         <slf4j.version>2.0.18</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <jackson.version>2.22.0</jackson.version>
-        <!-- jackson-annotations publishes 2.22 (no patch), not 2.22.0 — pin separately so resolution doesn't fail -->
-        <jackson-annotations.version>2.22</jackson-annotations.version>
+        <jackson.bom.version>2.22.0</jackson.bom.version>
         <jfairy.version>0.5.9</jfairy.version>
-        <gcloud.version>1.94.0</gcloud.version>
+        <gcloud.version>1.95.0</gcloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <!--
+                  Jackson modules are versioned individually: jackson-core/jackson-databind ship as 2.22.0
+                  while jackson-annotations ships as 2.22 (no patch segment). The BOM maps each module to its
+                  correct version, so we must not pin a single ${jackson.version} across all three.
+                -->
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured-bom</artifactId>
@@ -74,17 +84,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -29,6 +29,8 @@
         <slf4j.version>2.0.18</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jackson.version>2.22.0</jackson.version>
+        <!-- jackson-annotations publishes 2.22 (no patch), not 2.22.0 — pin separately so resolution doesn't fail -->
+        <jackson-annotations.version>2.22</jackson-annotations.version>
         <jfairy.version>0.5.9</jfairy.version>
         <gcloud.version>1.94.0</gcloud.version>
     </properties>
@@ -82,7 +84,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -309,6 +309,8 @@ spec:
               value: '{{- include "dnastack.app.version" . }}'
             - name: WES_AUTH_ISSUERURI
               value: '{{- include "dnastack.wallet.externalUrl" . }}'
+            - name: APP_RBAC_FINE_GRAINED_ENFORCEMENT_ENABLED
+              value: {{ .Values.app.rbac.fineGrainedEnforcementEnabled | quote }}
             - name: MANAGEMENT_METRICS_TAGS_REGION
               value: '{{- include "dnastack.workspacesWes.externalUrl" . }}'
             - name: WES_REGISTRY_CLIENT_ID

--- a/helm/templates/resources/app.yaml
+++ b/helm/templates/resources/app.yaml
@@ -201,5 +201,13 @@ spec:
           - wes:runs:write
           - wes:runs:cancel
           - wes:execute
+          - workbench.runs.execute
+          - workbench.runs.list
+          - workbench.runs.get
+          - workbench.runs.cancel
+          - workbench.runs.logs.get
+          - workbench.runs.files.list
+          - workbench.runs.files.get
+          - workbench.runs.files.delete
         resources:
           - uri: '{{- include "dnastack.workspacesWes.externalUrl" . }}/'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,6 +32,10 @@ app:
   secretHash: secrets-hash
   memoryLimit: "2048Mi"
   replicas: 1
+  rbac:
+    # false: @PreAuthorize endpoints enforce coarse wes:* actions; true: enforce fine workbench.runs.* actions.
+    # Each environment flips this in helm/<env>/global-values.yaml once its consumer grants carry the fine actions.
+    fineGrainedEnforcementEnabled: false
   spring:
     additionalProfiles: ""
 

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -69,7 +69,7 @@ public class WesV1Controller {
     }
 
 
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.execute', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', {'wes:execute','workbench.runs.execute'}, 'wes')")
     @PostMapping(value = "/runs", produces = {
         MediaType.APPLICATION_JSON_VALUE
     }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -94,7 +94,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:runs:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.list', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', {'wes:runs:read','workbench.runs.list'}, 'wes')")
     @GetMapping(path = "/runs", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunListResponse getRuns(
         @RequestParam(value = "page_size", required = false) Integer pageSize,
@@ -104,21 +104,21 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:read")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.get'}, 'wes')")
     @GetMapping(value = "/runs/{run_id}", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunLog getRun(@PathVariable("run_id") String runId) {
         return adapter.getRun(runId);
     }
 
     @AuditActionUri("wes:run:status")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.get'}, 'wes')")
     @GetMapping(value = "/runs/{run_id}/status", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunStatus getRunStatus(@PathVariable("run_id") String runId) {
         return adapter.getRunStatus(runId);
     }
 
     @AuditActionUri("wes:run:cancel")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.cancel', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:cancel','workbench.runs.cancel'}, 'wes')")
     @PostMapping(path = "/runs/{runId}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunId cancelRun(@PathVariable("runId") String runId) {
         return adapter.cancel(runId);
@@ -126,14 +126,14 @@ public class WesV1Controller {
 
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
         adapter.getLogBytes(response.getOutputStream(), runId, RangeHeaderUtils.getRangeFromHeaders(response, headers));
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -145,7 +145,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,
@@ -157,7 +157,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -170,7 +170,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -69,7 +69,7 @@ public class WesV1Controller {
     }
 
 
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:execute', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.execute', 'wes')")
     @PostMapping(value = "/runs", produces = {
         MediaType.APPLICATION_JSON_VALUE
     }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -94,7 +94,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:runs:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.list', 'wes')")
     @GetMapping(path = "/runs", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunListResponse getRuns(
         @RequestParam(value = "page_size", required = false) Integer pageSize,
@@ -104,21 +104,21 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:read")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunLog getRun(@PathVariable("run_id") String runId) {
         return adapter.getRun(runId);
     }
 
     @AuditActionUri("wes:run:status")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}/status", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunStatus getRunStatus(@PathVariable("run_id") String runId) {
         return adapter.getRunStatus(runId);
     }
 
     @AuditActionUri("wes:run:cancel")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:cancel', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.cancel', 'wes')")
     @PostMapping(path = "/runs/{runId}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunId cancelRun(@PathVariable("runId") String runId) {
         return adapter.cancel(runId);
@@ -126,14 +126,14 @@ public class WesV1Controller {
 
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
         adapter.getLogBytes(response.getOutputStream(), runId, RangeHeaderUtils.getRangeFromHeaders(response, headers));
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -145,7 +145,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,
@@ -157,7 +157,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -170,7 +170,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,

--- a/src/main/java/com/dnastack/wes/files/RunFileController.java
+++ b/src/main/java/com/dnastack/wes/files/RunFileController.java
@@ -22,21 +22,21 @@ public class RunFileController {
     public RunFileController(RunFileService runFileService) {this.runFileService = runFileService;}
 
     @AuditActionUri("wes:runs:files:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.list', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.list'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFiles getRunFiles(@PathVariable String runId) {
         return runFileService.getRunFiles(runId);
     }
 
     @AuditActionUri("wes:runs:files:get-metadata")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFile getRunFile(@PathVariable String runId, @RequestParam String path) {
         return runFileService.getRunFile(runId,path);
     }
 
     @AuditActionUri("wes:runs:files:get-content")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.get'}, 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     public void streamFileContents(
         HttpServletResponse response,
@@ -50,7 +50,7 @@ public class RunFileController {
 
 
     @AuditActionUri("wes:run:files:delete")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.delete', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:write','workbench.runs.files.delete'}, 'wes')")
     @DeleteMapping(value = "/runs/{run_id}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFileDeletions deleteRunFiles(
         @PathVariable("run_id") String runId,

--- a/src/main/java/com/dnastack/wes/files/RunFileController.java
+++ b/src/main/java/com/dnastack/wes/files/RunFileController.java
@@ -22,21 +22,21 @@ public class RunFileController {
     public RunFileController(RunFileService runFileService) {this.runFileService = runFileService;}
 
     @AuditActionUri("wes:runs:files:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.list', 'wes')")
     @GetMapping(value = "/runs/{runId}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFiles getRunFiles(@PathVariable String runId) {
         return runFileService.getRunFiles(runId);
     }
 
     @AuditActionUri("wes:runs:files:get-metadata")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFile getRunFile(@PathVariable String runId, @RequestParam String path) {
         return runFileService.getRunFile(runId,path);
     }
 
     @AuditActionUri("wes:runs:files:get-content")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:read', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     public void streamFileContents(
         HttpServletResponse response,
@@ -50,7 +50,7 @@ public class RunFileController {
 
 
     @AuditActionUri("wes:run:files:delete")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'wes:runs:write', 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.delete', 'wes')")
     @DeleteMapping(value = "/runs/{run_id}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFileDeletions deleteRunFiles(
         @PathVariable("run_id") String runId,

--- a/src/main/java/com/dnastack/wes/security/AccessEvaluator.java
+++ b/src/main/java/com/dnastack/wes/security/AccessEvaluator.java
@@ -9,15 +9,20 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class AccessEvaluator {
 
+    static final String FINE_GRAINED_ACTION_PREFIX = "workbench.";
+
     private final List<String> audiences;
+    private final boolean fineGrainedEnforcementEnabled;
     private final PermissionChecker permissionChecker;
 
-    public AccessEvaluator(AuthConfig authConfig, PermissionChecker permissionChecker) {
+    public AccessEvaluator(AuthConfig authConfig, boolean fineGrainedEnforcementEnabled, PermissionChecker permissionChecker) {
         this.audiences = authConfig.tokenIssuer.getAudiences();
+        this.fineGrainedEnforcementEnabled = fineGrainedEnforcementEnabled;
         this.permissionChecker = permissionChecker;
     }
 
@@ -34,8 +39,13 @@ public class AccessEvaluator {
      * Add the above line with appropriate api endpoint, actions and scopes on a controller method
      * to preauthorize the request
      * Additionally, you can handle exceptions using @ExceptionHandler
+     *
+     * <p>An endpoint may pass both a coarse action and its fine {@code workbench.*} equivalent in
+     * {@code requiredActions}; {@link #selectEnforcedActions(Set)} keeps only the side that
+     * {@code app.rbac.fine-grained-enforcement.enabled} selects before delegating.
      */
     public boolean canAccessResource(String requiredResource, Set<String> requiredActions, Set<String> requiredScopes) {
+        final Set<String> enforcedActions = selectEnforcedActions(requiredActions);
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             log.warn("Authentication must be present in context, resolving access as denied.");
@@ -50,16 +60,29 @@ public class AccessEvaluator {
             .map(jwtPrincipal -> {
                 boolean hasPermissions = audiences.stream().anyMatch(audience -> {
                     final String fullResourceUrl = audience + requiredResource;
-                    return permissionChecker.hasPermissions(jwtPrincipal.getTokenValue(), requiredScopes, fullResourceUrl, requiredActions);
+                    return permissionChecker.hasPermissions(jwtPrincipal.getTokenValue(), requiredScopes, fullResourceUrl, enforcedActions);
                 });
                 if (!hasPermissions) {
                     log.info("Denying access to {} for {}. allowedAudiences={}; requiredScopes={}; requiredActions={}; actualScopes={}; actualActions={}",
-                        jwtPrincipal.getSubject(), requiredResource, audiences, requiredScopes, requiredActions,
+                        jwtPrincipal.getSubject(), requiredResource, audiences, requiredScopes, enforcedActions,
                         jwtPrincipal.getClaims().get("scope"), jwtPrincipal.getClaims().get("actions"));
                 }
                 return hasPermissions;
             })
             .orElse(false);
+    }
+
+    /**
+     * Returns the subset of {@code requiredActions} that must be enforced: fine {@code workbench.*} actions when
+     * fine-grained enforcement is enabled, coarse actions otherwise. The downstream {@link PermissionChecker}
+     * requires the caller to hold <em>every</em> action handed to it, so coarse and fine cannot be passed
+     * together — exactly one side is selected here. A set already holding a single side is returned unchanged.
+     */
+    Set<String> selectEnforcedActions(Set<String> requiredActions) {
+        final Set<String> selected = requiredActions.stream()
+            .filter(action -> fineGrainedEnforcementEnabled == action.startsWith(FINE_GRAINED_ACTION_PREFIX))
+            .collect(Collectors.toSet());
+        return selected.isEmpty() ? requiredActions : selected;
     }
 
 }

--- a/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
+++ b/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
@@ -31,8 +31,12 @@ import java.util.List;
 public class PassportSecurityConfiguration {
 
     @Bean
-    public AccessEvaluator accessEvaluator(AuthConfig authConfig, PermissionChecker permissionChecker) {
-        return new AccessEvaluator(authConfig, permissionChecker);
+    public AccessEvaluator accessEvaluator(
+        AuthConfig authConfig,
+        @Value("${app.rbac.fine-grained-enforcement.enabled:false}") boolean fineGrainedEnforcementEnabled,
+        PermissionChecker permissionChecker
+    ) {
+        return new AccessEvaluator(authConfig, fineGrainedEnforcementEnabled, permissionChecker);
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -161,6 +161,10 @@ wes:
 # Auditing
 app:
   url: ${wes.url}
+  rbac:
+    fine-grained-enforcement:
+      # false: endpoints enforce their coarse wes:* action; true: enforce the fine workbench.runs.* action.
+      enabled: false
 
 auditing:
   enabled: true

--- a/src/test/java/com/dnastack/wes/security/AccessEvaluatorTest.java
+++ b/src/test/java/com/dnastack/wes/security/AccessEvaluatorTest.java
@@ -1,0 +1,111 @@
+package com.dnastack.wes.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dnastack.auth.PermissionChecker;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class AccessEvaluatorTest {
+
+    private static final String AUDIENCE = "http://localhost:8090";
+
+    private final PermissionChecker permissionChecker = mock(PermissionChecker.class);
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private AccessEvaluator evaluator(boolean fineGrainedEnabled) {
+        AuthConfig authConfig = new AuthConfig();
+        AuthConfig.IssuerConfig issuerConfig = new AuthConfig.IssuerConfig();
+        issuerConfig.setAudiences(List.of(AUDIENCE));
+        authConfig.tokenIssuer = issuerConfig;
+        return new AccessEvaluator(authConfig, fineGrainedEnabled, permissionChecker);
+    }
+
+    @Test
+    void selectEnforcedActions_whenDisabled_keepsOnlyCoarse() {
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get")))
+            .containsExactly("wes:runs:read");
+    }
+
+    @Test
+    void selectEnforcedActions_whenEnabled_keepsOnlyFine() {
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get")))
+            .containsExactly("workbench.runs.get");
+    }
+
+    @Test
+    void selectEnforcedActions_forUnmigratedSingleAction_returnsItUnderEitherState() {
+        Set<String> coarseOnly = Set.of("wes:execute");
+        assertThat(evaluator(false).selectEnforcedActions(coarseOnly)).containsExactly("wes:execute");
+        assertThat(evaluator(true).selectEnforcedActions(coarseOnly)).containsExactly("wes:execute");
+    }
+
+    @Test
+    void selectEnforcedActions_whenDisabled_foldsEveryReadEndpointBackOntoTheSharedCoarseAction() {
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.list"))).containsExactly("wes:runs:read");
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get"))).containsExactly("wes:runs:read");
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.logs.get"))).containsExactly("wes:runs:read");
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.list"))).containsExactly("wes:runs:read");
+        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.get"))).containsExactly("wes:runs:read");
+    }
+
+    @Test
+    void selectEnforcedActions_whenEnabled_separatesEachReadEndpointOntoItsOwnFineAction() {
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.list"))).containsExactly("workbench.runs.list");
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get"))).containsExactly("workbench.runs.get");
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.logs.get"))).containsExactly("workbench.runs.logs.get");
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.list"))).containsExactly("workbench.runs.files.list");
+        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.get"))).containsExactly("workbench.runs.files.get");
+    }
+
+    @Test
+    void canAccessResource_whenDisabled_forwardsOnlyCoarseToPermissionChecker() {
+        givenAuthenticatedJwt();
+        ArgumentCaptor<Set<String>> forwarded = captureForwardedActions();
+
+        evaluator(false).canAccessResource("/ga4gh/wes/v1/runs", Set.of("wes:runs:read", "workbench.runs.list"), Set.of("wes"));
+
+        verify(permissionChecker).hasPermissions(eq("token-value"), any(), eq(AUDIENCE + "/ga4gh/wes/v1/runs"), forwarded.capture());
+        assertThat(forwarded.getValue()).containsExactly("wes:runs:read");
+    }
+
+    @Test
+    void canAccessResource_whenEnabled_forwardsOnlyFineToPermissionChecker() {
+        givenAuthenticatedJwt();
+        ArgumentCaptor<Set<String>> forwarded = captureForwardedActions();
+
+        evaluator(true).canAccessResource("/ga4gh/wes/v1/runs", Set.of("wes:runs:read", "workbench.runs.list"), Set.of("wes"));
+
+        verify(permissionChecker).hasPermissions(eq("token-value"), any(), eq(AUDIENCE + "/ga4gh/wes/v1/runs"), forwarded.capture());
+        assertThat(forwarded.getValue()).containsExactly("workbench.runs.list");
+    }
+
+    private void givenAuthenticatedJwt() {
+        Jwt jwt = Jwt.withTokenValue("token-value")
+            .header("alg", "none")
+            .claim("sub", "test-user")
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(jwt, null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<Set<String>> captureForwardedActions() {
+        when(permissionChecker.hasPermissions(any(), any(), any(), any())).thenReturn(true);
+        return ArgumentCaptor.forClass(Set.class);
+    }
+}


### PR DESCRIPTION
Relands the reverted fine-grained `workbench.*` `@PreAuthorize` enforcement, now gated behind `app.rbac.fine-grained-enforcement.enabled` (default **false**).

### Why
The 2026-06-24 rollout hard-replaced coarse → fine actions with no flag, so each endpoint *required* the fine action before consumers were granted it → 403 cascade (reverted). This reland makes enforcement reversible and **inert by default**: with the flag **off** the service enforces its original coarse action **byte-for-byte** (`AccessEvaluator` forwards only the coarse side of each dual `{coarse, fine}` action set to the AND-matching `PermissionChecker`); with it **on** it enforces the fine `workbench.*` action (least privilege per the frozen action→role matrix).

### Rollout
- **Stage 1** — merge + deploy flag-OFF (inert; safe in any order).
- **Stage 2** — set `APP_RBAC_FINE_GRAINED_ENFORCEMENT_ENABLED=true` in `helm/<env>/global-values.yaml`, **WUS-first**, once this service's consumer fine grants are reconciled in that environment. Reversible by flipping the flag back (no redeploy).

### Verification
`AccessEvaluatorTest` proves the partition under both flag states. The cross-service `TertiaryAnalysisJourneyTest` ran **green against a re-provisioned local stack in both flag states** — Stage-1 (flags OFF) and Stage-2 (all 6 flags ON): 3/3 tests, **0 authorization 403s**, a real ~20-min Cromwell ingest each.

### This service
Raw GA4GH WES (`:8090`), flat-policy granted, not namespace-scoped. Flag + partition added to its own `AccessEvaluator` (partitions the action set once before the audiences loop). The 8 `workbench.runs.*` actions are dual-granted to all `:8090` principals. The branch's jackson e2e-pom change is dropped in favour of main's jackson-bom. Enforcement is active only under `wes.auth.method == PASSPORT`.

Part of the coordinated reland across workbench-user-service + sample/workflow/ewes/bridge/cromwell-wes + dnastack-development-tools (local Wallet grants) + workbench-frontend (BFF grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
