### PR TITLE
[CU-86bav3b9n] Phase 3: make fine-grained RBAC enforcement permanent

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -309,8 +309,6 @@ spec:
               value: '{{- include "dnastack.app.version" . }}'
             - name: WES_AUTH_ISSUERURI
               value: '{{- include "dnastack.wallet.externalUrl" . }}'
-            - name: APP_RBAC_FINE_GRAINED_ENFORCEMENT_ENABLED
-              value: {{ .Values.app.rbac.fineGrainedEnforcementEnabled | quote }}
             - name: MANAGEMENT_METRICS_TAGS_REGION
               value: '{{- include "dnastack.workspacesWes.externalUrl" . }}'
             - name: WES_REGISTRY_CLIENT_ID

--- a/helm/templates/resources/app.yaml
+++ b/helm/templates/resources/app.yaml
@@ -197,10 +197,6 @@ spec:
           - type: group
             id: dnastack-devs-external
         actions:
-          - wes:runs:read
-          - wes:runs:write
-          - wes:runs:cancel
-          - wes:execute
           - workbench.runs.execute
           - workbench.runs.list
           - workbench.runs.get

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,10 +32,6 @@ app:
   secretHash: secrets-hash
   memoryLimit: "2048Mi"
   replicas: 1
-  rbac:
-    # false: @PreAuthorize endpoints enforce coarse wes:* actions; true: enforce fine workbench.runs.* actions.
-    # Each environment flips this in helm/<env>/global-values.yaml once its consumer grants carry the fine actions.
-    fineGrainedEnforcementEnabled: false
   spring:
     additionalProfiles: ""
 

--- a/src/main/java/com/dnastack/wes/api/WesV1Controller.java
+++ b/src/main/java/com/dnastack/wes/api/WesV1Controller.java
@@ -69,7 +69,7 @@ public class WesV1Controller {
     }
 
 
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', {'wes:execute','workbench.runs.execute'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.execute', 'wes')")
     @PostMapping(value = "/runs", produces = {
         MediaType.APPLICATION_JSON_VALUE
     }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -94,7 +94,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:runs:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', {'wes:runs:read','workbench.runs.list'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs', 'workbench.runs.list', 'wes')")
     @GetMapping(path = "/runs", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunListResponse getRuns(
         @RequestParam(value = "page_size", required = false) Integer pageSize,
@@ -104,21 +104,21 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:read")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunLog getRun(@PathVariable("run_id") String runId) {
         return adapter.getRun(runId);
     }
 
     @AuditActionUri("wes:run:status")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.get', 'wes')")
     @GetMapping(value = "/runs/{run_id}/status", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunStatus getRunStatus(@PathVariable("run_id") String runId) {
         return adapter.getRunStatus(runId);
     }
 
     @AuditActionUri("wes:run:cancel")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:cancel','workbench.runs.cancel'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.cancel', 'wes')")
     @PostMapping(path = "/runs/{runId}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
     public RunId cancelRun(@PathVariable("runId") String runId) {
         return adapter.cancel(runId);
@@ -126,14 +126,14 @@ public class WesV1Controller {
 
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getStderr(HttpServletResponse response, @RequestHeader HttpHeaders headers, @PathVariable String runId) throws IOException {
         adapter.getLogBytes(response.getOutputStream(), runId, RangeHeaderUtils.getRangeFromHeaders(response, headers));
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -145,7 +145,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskId}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,
@@ -157,7 +157,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stderr")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stderr", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStderr(
         HttpServletResponse response,
@@ -170,7 +170,7 @@ public class WesV1Controller {
     }
 
     @AuditActionUri("wes:run:stdout")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.logs.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.logs.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/logs/task/{taskName}/{index}/stdout", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void getTaskStdout(
         HttpServletResponse response,

--- a/src/main/java/com/dnastack/wes/files/RunFileController.java
+++ b/src/main/java/com/dnastack/wes/files/RunFileController.java
@@ -22,21 +22,21 @@ public class RunFileController {
     public RunFileController(RunFileService runFileService) {this.runFileService = runFileService;}
 
     @AuditActionUri("wes:runs:files:list")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.list'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.list', 'wes')")
     @GetMapping(value = "/runs/{runId}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFiles getRunFiles(@PathVariable String runId) {
         return runFileService.getRunFiles(runId);
     }
 
     @AuditActionUri("wes:runs:files:get-metadata")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFile getRunFile(@PathVariable String runId, @RequestParam String path) {
         return runFileService.getRunFile(runId,path);
     }
 
     @AuditActionUri("wes:runs:files:get-content")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:read','workbench.runs.files.get'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.get', 'wes')")
     @GetMapping(value = "/runs/{runId}/file", produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     public void streamFileContents(
         HttpServletResponse response,
@@ -50,7 +50,7 @@ public class RunFileController {
 
 
     @AuditActionUri("wes:run:files:delete")
-    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, {'wes:runs:write','workbench.runs.files.delete'}, 'wes')")
+    @PreAuthorize("@accessEvaluator.canAccessResource('/ga4gh/wes/v1/runs/' + #runId, 'workbench.runs.files.delete', 'wes')")
     @DeleteMapping(value = "/runs/{run_id}/files", produces = { MediaType.APPLICATION_JSON_VALUE })
     public RunFileDeletions deleteRunFiles(
         @PathVariable("run_id") String runId,

--- a/src/main/java/com/dnastack/wes/security/AccessEvaluator.java
+++ b/src/main/java/com/dnastack/wes/security/AccessEvaluator.java
@@ -9,20 +9,15 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class AccessEvaluator {
 
-    static final String FINE_GRAINED_ACTION_PREFIX = "workbench.";
-
     private final List<String> audiences;
-    private final boolean fineGrainedEnforcementEnabled;
     private final PermissionChecker permissionChecker;
 
-    public AccessEvaluator(AuthConfig authConfig, boolean fineGrainedEnforcementEnabled, PermissionChecker permissionChecker) {
+    public AccessEvaluator(AuthConfig authConfig, PermissionChecker permissionChecker) {
         this.audiences = authConfig.tokenIssuer.getAudiences();
-        this.fineGrainedEnforcementEnabled = fineGrainedEnforcementEnabled;
         this.permissionChecker = permissionChecker;
     }
 
@@ -39,13 +34,8 @@ public class AccessEvaluator {
      * Add the above line with appropriate api endpoint, actions and scopes on a controller method
      * to preauthorize the request
      * Additionally, you can handle exceptions using @ExceptionHandler
-     *
-     * <p>An endpoint may pass both a coarse action and its fine {@code workbench.*} equivalent in
-     * {@code requiredActions}; {@link #selectEnforcedActions(Set)} keeps only the side that
-     * {@code app.rbac.fine-grained-enforcement.enabled} selects before delegating.
      */
     public boolean canAccessResource(String requiredResource, Set<String> requiredActions, Set<String> requiredScopes) {
-        final Set<String> enforcedActions = selectEnforcedActions(requiredActions);
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             log.warn("Authentication must be present in context, resolving access as denied.");
@@ -60,29 +50,16 @@ public class AccessEvaluator {
             .map(jwtPrincipal -> {
                 boolean hasPermissions = audiences.stream().anyMatch(audience -> {
                     final String fullResourceUrl = audience + requiredResource;
-                    return permissionChecker.hasPermissions(jwtPrincipal.getTokenValue(), requiredScopes, fullResourceUrl, enforcedActions);
+                    return permissionChecker.hasPermissions(jwtPrincipal.getTokenValue(), requiredScopes, fullResourceUrl, requiredActions);
                 });
                 if (!hasPermissions) {
                     log.info("Denying access to {} for {}. allowedAudiences={}; requiredScopes={}; requiredActions={}; actualScopes={}; actualActions={}",
-                        jwtPrincipal.getSubject(), requiredResource, audiences, requiredScopes, enforcedActions,
+                        jwtPrincipal.getSubject(), requiredResource, audiences, requiredScopes, requiredActions,
                         jwtPrincipal.getClaims().get("scope"), jwtPrincipal.getClaims().get("actions"));
                 }
                 return hasPermissions;
             })
             .orElse(false);
-    }
-
-    /**
-     * Returns the subset of {@code requiredActions} that must be enforced: fine {@code workbench.*} actions when
-     * fine-grained enforcement is enabled, coarse actions otherwise. The downstream {@link PermissionChecker}
-     * requires the caller to hold <em>every</em> action handed to it, so coarse and fine cannot be passed
-     * together — exactly one side is selected here. A set already holding a single side is returned unchanged.
-     */
-    Set<String> selectEnforcedActions(Set<String> requiredActions) {
-        final Set<String> selected = requiredActions.stream()
-            .filter(action -> fineGrainedEnforcementEnabled == action.startsWith(FINE_GRAINED_ACTION_PREFIX))
-            .collect(Collectors.toSet());
-        return selected.isEmpty() ? requiredActions : selected;
     }
 
 }

--- a/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
+++ b/src/main/java/com/dnastack/wes/security/PassportSecurityConfiguration.java
@@ -33,10 +33,9 @@ public class PassportSecurityConfiguration {
     @Bean
     public AccessEvaluator accessEvaluator(
         AuthConfig authConfig,
-        @Value("${app.rbac.fine-grained-enforcement.enabled:false}") boolean fineGrainedEnforcementEnabled,
         PermissionChecker permissionChecker
     ) {
-        return new AccessEvaluator(authConfig, fineGrainedEnforcementEnabled, permissionChecker);
+        return new AccessEvaluator(authConfig, permissionChecker);
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -161,10 +161,6 @@ wes:
 # Auditing
 app:
   url: ${wes.url}
-  rbac:
-    fine-grained-enforcement:
-      # false: endpoints enforce their coarse wes:* action; true: enforce the fine workbench.runs.* action.
-      enabled: false
 
 auditing:
   enabled: true

--- a/src/test/java/com/dnastack/wes/security/AccessEvaluatorTest.java
+++ b/src/test/java/com/dnastack/wes/security/AccessEvaluatorTest.java
@@ -28,68 +28,20 @@ class AccessEvaluatorTest {
         SecurityContextHolder.clearContext();
     }
 
-    private AccessEvaluator evaluator(boolean fineGrainedEnabled) {
+    private AccessEvaluator evaluator() {
         AuthConfig authConfig = new AuthConfig();
         AuthConfig.IssuerConfig issuerConfig = new AuthConfig.IssuerConfig();
         issuerConfig.setAudiences(List.of(AUDIENCE));
         authConfig.tokenIssuer = issuerConfig;
-        return new AccessEvaluator(authConfig, fineGrainedEnabled, permissionChecker);
+        return new AccessEvaluator(authConfig, permissionChecker);
     }
 
     @Test
-    void selectEnforcedActions_whenDisabled_keepsOnlyCoarse() {
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get")))
-            .containsExactly("wes:runs:read");
-    }
-
-    @Test
-    void selectEnforcedActions_whenEnabled_keepsOnlyFine() {
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get")))
-            .containsExactly("workbench.runs.get");
-    }
-
-    @Test
-    void selectEnforcedActions_forUnmigratedSingleAction_returnsItUnderEitherState() {
-        Set<String> coarseOnly = Set.of("wes:execute");
-        assertThat(evaluator(false).selectEnforcedActions(coarseOnly)).containsExactly("wes:execute");
-        assertThat(evaluator(true).selectEnforcedActions(coarseOnly)).containsExactly("wes:execute");
-    }
-
-    @Test
-    void selectEnforcedActions_whenDisabled_foldsEveryReadEndpointBackOntoTheSharedCoarseAction() {
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.list"))).containsExactly("wes:runs:read");
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get"))).containsExactly("wes:runs:read");
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.logs.get"))).containsExactly("wes:runs:read");
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.list"))).containsExactly("wes:runs:read");
-        assertThat(evaluator(false).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.get"))).containsExactly("wes:runs:read");
-    }
-
-    @Test
-    void selectEnforcedActions_whenEnabled_separatesEachReadEndpointOntoItsOwnFineAction() {
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.list"))).containsExactly("workbench.runs.list");
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.get"))).containsExactly("workbench.runs.get");
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.logs.get"))).containsExactly("workbench.runs.logs.get");
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.list"))).containsExactly("workbench.runs.files.list");
-        assertThat(evaluator(true).selectEnforcedActions(Set.of("wes:runs:read", "workbench.runs.files.get"))).containsExactly("workbench.runs.files.get");
-    }
-
-    @Test
-    void canAccessResource_whenDisabled_forwardsOnlyCoarseToPermissionChecker() {
+    void canAccessResource_forwardsRequiredActionsVerbatimToPermissionChecker() {
         givenAuthenticatedJwt();
         ArgumentCaptor<Set<String>> forwarded = captureForwardedActions();
 
-        evaluator(false).canAccessResource("/ga4gh/wes/v1/runs", Set.of("wes:runs:read", "workbench.runs.list"), Set.of("wes"));
-
-        verify(permissionChecker).hasPermissions(eq("token-value"), any(), eq(AUDIENCE + "/ga4gh/wes/v1/runs"), forwarded.capture());
-        assertThat(forwarded.getValue()).containsExactly("wes:runs:read");
-    }
-
-    @Test
-    void canAccessResource_whenEnabled_forwardsOnlyFineToPermissionChecker() {
-        givenAuthenticatedJwt();
-        ArgumentCaptor<Set<String>> forwarded = captureForwardedActions();
-
-        evaluator(true).canAccessResource("/ga4gh/wes/v1/runs", Set.of("wes:runs:read", "workbench.runs.list"), Set.of("wes"));
+        evaluator().canAccessResource("/ga4gh/wes/v1/runs", Set.of("workbench.runs.list"), Set.of("wes"));
 
         verify(permissionChecker).hasPermissions(eq("token-value"), any(), eq(AUDIENCE + "/ga4gh/wes/v1/runs"), forwarded.capture());
         assertThat(forwarded.getValue()).containsExactly("workbench.runs.list");


### PR DESCRIPTION
## Why
Fine-grained RBAC is ON in alpha & prod, so the coarse↔fine dual scaffolding is dead.

## What
- Collapse the dual `{coarse, fine}` `@PreAuthorize` sets in `WesV1Controller` + `RunFileController` → the single `workbench.runs.*` action
- Remove the flag `@Value` from `PassportSecurityConfiguration` + the `AccessEvaluator` partition; strip it from `application.yaml` + helm
- Drop the 4 coarse `wes:*` from the `workspaces-wes` policy (keep the 8 `workbench.runs.*`)

## Testing
`./mvnw test` + `verify` green (18 tests). `service-info`/service-registry stay `permitAll`.
