### PR TITLE
[CU-86bbtru6q] Point Cromwell's Batch localization image at our own mirror

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -58,6 +58,11 @@ data:
 
     google {
       application-name = "cromwell"
+
+      # Cromwell's GCP Batch backend otherwise defaults to a gcr.io cloud-sdk tag that Google
+      # garbage-collects once it ages out, which fails every task at VM startup on the docker pull.
+      cloud-sdk-image-url = "{{ .Values.app.cromwell.cloudSdkImage }}"
+
       auths = [
         {
           name = "cromwell-service-account"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,6 +48,11 @@ app:
     gcpStagingLocation: ""    # GCS staging location for WES blob storage
     gcpZone: "us-central1-a"  # GCP zone for Cromwell batch jobs
     cromwellUrl: "http://localhost:8000"  # in-pod URL to the Cromwell sidecar
+    # Image Cromwell's GCP Batch backend runs its localization/delocalization runnables in.
+    # Must be a `slim` variant: alpine moved python to /usr/local/bin at 568.0.0, and Cromwell
+    # sets the runnable entrypoint to /bin/sh, so gsutil's preamble fails on /usr/bin/python3.
+    # The Batch worker service account needs artifactregistry.reader on the mirror's project.
+    cloudSdkImage: "us-central1-docker.pkg.dev/dnastack-container-store/mirror-images/google.com/cloudsdktool/cloud-sdk:583.0.0-slim"
 
 workspacesWes:
   appName:


### PR DESCRIPTION
Closes part of [CU-86bbtru6q](https://app.clickup.com/t/86bbtru6q). Root cause and the fleet-wide fix are on [CU-86bbrdj6w](https://app.clickup.com/t/86bbrdj6w).

## ⚠️ Do not merge before the IAM grant

The mirror 403s until the workbench Batch worker service account can read it. Verified 2026-09-02 that `593521415818-compute@developer.gserviceaccount.com` (project `ardent-window-817`, shared by alpha, prod-us, staging and preview) has no read on `dnastack-container-store` at project, folder or org level, and `mirror-images` has no repo-level IAM at all. Merging first swaps a 404 for a 403 and puts alpha back to broken.

```
gcloud artifacts repositories add-iam-policy-binding mirror-images \
  --location=us-central1 --project=dnastack-container-store \
  --member="serviceAccount:593521415818-compute@developer.gserviceaccount.com" \
  --role="roles/artifactregistry.reader"
```

## Why

Google garbage-collected every `cloud-sdk` tag older than about twelve months on 2026-08-31, taking `461.0.0-alpine` with it. Cromwell's GCP Batch backend hardcodes that tag for all fifteen of its localization and delocalization runnables, so the Batch VM fails at startup on the docker pull, retries four times, and the run lands in `EXECUTOR_ERROR` with an empty errors list:

```
Error response from daemon: manifest for gcr.io/google.com/cloudsdktool/cloud-sdk:461.0.0-alpine
  not found: manifest unknown: Failed to fetch "461.0.0-alpine"
[Batch Action] Docker credential helper exited 1 (tried 4/4), no more retries left.
```

`RunnableUtils.CloudSdkImage = config.getOrElse("cloud-sdk-image-url", "…461.0.0-alpine")` is identical in Cromwell 89, 92 and develop, so upgrading does not help. The override key is read from the top-level `google { }` block and is present in the shipped class, so no Cromwell change is needed.

## Slim, not alpine

A newer alpine tag pulls cleanly and still fails every task at localization with `/google-cloud-sdk/bin/gsutil: line 202: /usr/bin/python3: not found`. Alpine moved python to `/usr/local/bin` at 568.0.0; Cromwell sets the runnable entrypoint to `/bin/sh`, bypassing the image's own entrypoint, so gsutil's preamble resolves `/usr/bin/python3` literally. Only alpine ≤ 567.0.0 satisfies it, an ageing line that breaks again on the next bump. `gsutil version` inside the image is not a valid check — it passes on images that fail under Cromwell, because it runs with the default entrypoint.

## Verification

Proven on alpha before this PR, using the byte-identical public tag (same config digest `sha256:09191ebd…`, same five layer digests as the mirror) because the IAM grant above is not in place yet:

- Hand-patched ConfigMap `cromwell-wes-service-cromwell-config`, restarted `workspaces-wes`
- Batch job `job-c798d235-6137-4f0c-8c87-68924b18c535` **SUCCEEDED** on `583.0.0-slim`, task `say_hello`
- `ewes-service-e2e-test-helm` **build 37 green**, 187 tests, 0 failures — first green since build 32 on 2026-08-17
- Cromwell status transitions went `Initializing → Running → Success`; before the fix every one was `Initializing → Failed`

That hand-patch is reverted by the next `helm upgrade`, which is what this PR replaces.

## Not covered here

Tracked on CU-86bbtru6q, listed so nobody assumes this PR closes them:

- `cloud-deployments/apps/workspaces-wes/runtime-config.yml:46` — prod-us + staging, still on Cromwell's broken default
- `development-environment-configuration/cds-apps/.../workspaces-wes/runtime-config.yml:46` — preview
- `cromwell-on-gcp-workbench-engine-installer/modules/cromwell/cromwell.conf:32` — customer-installed engines
- `cromwell-vm` in project `workbench-engine-it-test`, which reddens `workbench-alpha/workbench-journey-test`; its config is baked into `metadata_startup_script`, so it needs a manual edit plus a VM reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nSUGpdLSy414gNWvAduHQ
